### PR TITLE
Add .NET 10 support and improve ReactiveList behavior

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -34,6 +34,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup .NET (With cache)
+        uses: actions/setup-dotnet@v5.0.0
+        with:
+         dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+         dotnet-quality: 'preview'
+         cache: true
+         cache-dependency-path: |
+           **/Directory.Packages.props
+           **/*.sln
+           **/*.csproj
+           **/global.json
+           **/nuget.config
+
       - name: NBGV
         id: nbgv
         uses: dotnet/nbgv@master

--- a/.github/workflows/BuildOnly.yml
+++ b/.github/workflows/BuildOnly.yml
@@ -29,6 +29,23 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - name: Setup .NET (With cache)
+        uses: actions/setup-dotnet@v5.0.0
+        with:
+         dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+         dotnet-quality: 'preview'
+         cache: true
+         cache-dependency-path: |
+           **/Directory.Packages.props
+           **/*.sln
+           **/*.csproj
+           **/global.json
+           **/nuget.config
+
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/README.md
+++ b/README.md
@@ -1,39 +1,194 @@
 # ReactiveList
-A Reactive List giving observables for changes, and current list items.
-Based on DynamicData.
 
-# IReactiveList
-Inherits : 
-- IList of T
-- IList
-- IReadOnlyList of T
-- INotifyCollectionChanged
-- INotifyPropertyChanged
-- ICancelable
+A lightweight reactive list with fine-grained change tracking built on DynamicData and System.Reactive.
+
+The list exposes reactive streams for what changed (Added/Removed/Changed), and a stream of the current items snapshot, while also implementing common list interfaces and change notifications for easy UI binding.
+
+Targets: .NET Standard 2.0, .NET 8, .NET 9, .NET 10
 
 
-## Features
-- **Reactive**: The list is reactive, and will notify observers of changes.
------------------------------------------------------------------------------
-- **CurrentItems**: Observe the current list of items.
-- **Changed**: Observe changes to the list.
-- **Added**: Observe changes Added to the list.
-- **Removed**: Observe changes Removed from the list.
------------------------------------------------------------------------------
-- **Add**: Add an item to the list.
-- **AddRange**: Add a range of items to the list.
-- **CopyTo**: Copy the list to an array.
-- **Contains**: Check if the list contains an item.
-- **Count**: Get the count of items in the list.
-- **Clear**: Clear the list of all items.
-- **Dispose**: Dispose of the list.
-- **GetEnumerator: Get an enumerator for the list.
-- **Insert**: Insert an item at a specific index.
-- **IndexOf**: Get an item from the current list of items.
-- **Remove**: Remove an item from the list.
-- **RemoveAt**: Remove an item at a specific index.
-- **RemoveRange**: Remove a range of items from the list.
-- **ReplaceAll**: Replace the current list of items with a new list of items.
-- **Subscribe**: Subscribe to the list.
-- **Update**: Update an item in the list.
-- **Updated**: Observe changes Updated in the list.
+## Why use ReactiveList?
+- Reactive: Subscribe to changes as they happen.
+- UI-friendly: Implements `INotifyCollectionChanged` and `INotifyPropertyChanged`.
+- Easy binding: Exposes a `ReadOnlyObservableCollection<T>` for the current items.
+- Granular change info: Access the last Added/Removed/Changed batch via collections and/or observables.
+- Familiar API: Implements `IList<T>`, `IList`, `IReadOnlyList<T>`, and `ICancelable`.
+
+
+## Getting started
+
+Create a reactive list and subscribe to changes.
+
+```csharp
+using CP.Reactive;
+
+var list = new ReactiveList<string>();
+
+// React to items added in the last change
+var addedSub = list.Added.Subscribe(added =>
+{
+    Console.WriteLine($"Added: {string.Join(", ", added)}");
+});
+
+// React to items removed in the last change
+var removedSub = list.Removed.Subscribe(removed =>
+{
+    Console.WriteLine($"Removed: {string.Join(", ", removed)}");
+});
+
+// React to any items changed (add/remove/replace) in the last change
+var changedSub = list.Changed.Subscribe(changed =>
+{
+    Console.WriteLine($"Changed: {string.Join(", ", changed)}");
+});
+
+// Observe the current items (snapshot) whenever the count changes
+var currentSub = list.CurrentItems.Subscribe(items =>
+{
+    Console.WriteLine($"Current: [{string.Join(", ", items)}]");
+});
+
+// Work with the list just like a normal list
+list.Add("one");
+list.AddRange(["two", "three"]);
+list.Insert(1, "two-point-five");
+list.Remove("two");
+list.RemoveAt(0);
+list.RemoveRange(0, 1);
+
+// Replace all items in a single operation
+list.ReplaceAll(["a", "b", "c"]);
+
+// Update an item (replace a specific value)
+list.Update("b", "B");
+
+// Access the read-only view of items (UI binding friendly)
+var items = list.Items; // ReadOnlyObservableCollection<string>
+
+// Cleanup
+addedSub.Dispose();
+removedSub.Dispose();
+changedSub.Dispose();
+currentSub.Dispose();
+list.Dispose();
+```
+
+
+### WPF/WinUI binding
+
+Because `ReactiveList<T>` implements `INotifyCollectionChanged`, `INotifyPropertyChanged`, and `IEnumerable<T>`, you can bind directly.
+
+```csharp
+public sealed class MyViewModel
+{
+    public IReactiveList<string> Items { get; } = new ReactiveList<string>(new[] { "One", "Two" });
+}
+```
+
+```xml
+<ListBox ItemsSource="{Binding Items}" />
+```
+
+Alternatively, bind to `Items` for an explicit `ReadOnlyObservableCollection<T>`:
+
+```xml
+<ListBox ItemsSource="{Binding Items.Items}" />
+```
+
+
+## Behavior notes
+
+- Observables run on `Scheduler.Immediate` inside the list; if you update UI from subscriptions, dispatch to your UI thread.
+- `ItemsAdded`, `ItemsRemoved`, `ItemsChanged` are snapshots of the last change batch only (not cumulative).
+- `ReplaceAll(newItems)` raises a clear + add-range under the hood. After `ReplaceAll`:
+  - `ItemsRemoved` contains the cleared items.
+  - `ItemsAdded` contains the new items.
+  - `ItemsChanged` reflects the clear operation (the removed range).
+  - A `Reset` collection change notification is raised.
+
+
+## API quick reference
+
+Interfaces implemented:
+- `IList<T>`, `IList`, `IReadOnlyList<T>`
+- `INotifyCollectionChanged`, `INotifyPropertyChanged`
+- `ICancelable` (`IsDisposed`)
+
+Properties:
+- `ReadOnlyObservableCollection<T> Items` — current items for binding.
+- `ReadOnlyObservableCollection<T> ItemsAdded` — items added in the last change.
+- `ReadOnlyObservableCollection<T> ItemsRemoved` — items removed in the last change.
+- `ReadOnlyObservableCollection<T> ItemsChanged` — items changed (add/remove/replace) in the last change.
+- `IObservable<IEnumerable<T>> Added` — stream of items added each change.
+- `IObservable<IEnumerable<T>> Removed` — stream of items removed each change.
+- `IObservable<IEnumerable<T>> Changed` — stream of items changed each change.
+- `IObservable<IEnumerable<T>> CurrentItems` — current items snapshot on count changes.
+- `int Count`, `bool IsDisposed`.
+
+Indexers:
+- `T this[int index] { get; set; }`
+- `object? IList.this[int index] { get; set; }`
+
+Events:
+- `event NotifyCollectionChangedEventHandler? CollectionChanged`
+- `event PropertyChangedEventHandler? PropertyChanged`
+
+Operations:
+- `void Add(T item)`
+- `void AddRange(IEnumerable<T> items)`
+- `void Insert(int index, T item)`
+- `void InsertRange(int index, IEnumerable<T> items)`
+- `bool Remove(T item)` / `void Remove(IEnumerable<T> items)` / `void RemoveAt(int index)` / `void RemoveRange(int index, int count)`
+- `void Clear()`
+- `void ReplaceAll(IEnumerable<T> items)`
+- `void Update(T item, T newValue)`
+- `int IndexOf(T item)` / `bool Contains(T item)`
+- `void CopyTo(T[] array, int arrayIndex)` / `void CopyTo(Array array, int index)`
+- `IDisposable Subscribe(IObserver<IEnumerable<T>> observer)` (subscribes to `CurrentItems`)
+- `void Dispose()`
+
+
+## Examples
+
+ReplaceAll semantics:
+
+```csharp
+var list = new ReactiveList<string>(["one", "two"]);
+// At this point:
+// list.ItemsAdded.Count == 2
+// list.ItemsChanged.Count == 2
+// list.ItemsRemoved.Count == 0
+
+list.ReplaceAll(["three", "four", "five"]);
+
+// After ReplaceAll:
+// list.ItemsAdded.Count == 3           // new items
+// list.ItemsRemoved.Count == 2         // old items cleared
+// list.ItemsChanged.Count == 2         // clear change set (removed range)
+```
+
+Subscribe to snapshots of the current items:
+
+```csharp
+var list = new ReactiveList<int>();
+list.CurrentItems.Subscribe(items =>
+{
+    // Runs when Count changes
+    var sum = items.Sum();
+    Console.WriteLine($"Sum: {sum}");
+});
+
+list.AddRange([1, 2, 3]); // triggers CurrentItems
+list.Remove(2);           // triggers CurrentItems
+```
+
+
+## Building locally
+
+- Open the solution and build. Projects target `netstandard2.0` (library) and modern .NET versions for tests/apps.
+- Dependencies: `DynamicData`, `System.Reactive`.
+
+
+## License
+
+MIT

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.0",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
+  }
+}

--- a/src/ReactiveList.Test/ReactiveList.Tests.csproj
+++ b/src/ReactiveList.Test/ReactiveList.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0;net10.0-windows10.0.17763.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/src/ReactiveList/ReactiveList.csproj
+++ b/src/ReactiveList/ReactiveList.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>CP.Reactive</RootNamespace>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="DynamicData" Version="9.4.1" />
+    <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added .NET 10 to target frameworks and global.json. Updated GitHub Actions to cache and use .NET 8, 9, and 10 SDKs. Improved ReactiveList to handle empty collections in AddRange/InsertRange/Remove/RemoveRange, fixed ReplaceAll synchronization, and clarified resource disposal. Expanded and clarified README with usage, API, and binding details.