### PR TITLE
Update Reactive2DList docs and use collection expressions

### DIFF
--- a/src/ReactiveList/Reactive2DList.cs
+++ b/src/ReactiveList/Reactive2DList.cs
@@ -77,7 +77,7 @@ public class Reactive2DList<T> : ReactiveList<ReactiveList<T>>
 
         foreach (var item in items)
         {
-            Add(new ReactiveList<T>(item));
+            Add([.. item]);
         }
     }
 
@@ -110,7 +110,7 @@ public class Reactive2DList<T> : ReactiveList<ReactiveList<T>>
             return;
         }
 
-        base.Insert(index, new ReactiveList<T>(items));
+        base.Insert(index, [.. items]);
     }
 
     /// <summary>


### PR DESCRIPTION
Expanded the README with comprehensive documentation and usage examples for Reactive2DList. Refactored Reactive2DList.cs to use collection expressions ([.. items]) for constructing inner ReactiveList<T> instances, improving code clarity and conciseness.