### PR TITLE
Migrate to TUnit and expand cross-TFM support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,7 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
     <CoreTargetFrameworks>net8.0;net9.0;net10.0</CoreTargetFrameworks>
-    <WinTargetFrameworks>net472;net48;net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</WinTargetFrameworks>
+    <WinTargetFrameworks>net462;net472;net48;net481;net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</WinTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
     <CoreTargetFrameworks>$(CoreTargetFrameworks);$(WinTargetFrameworks)</CoreTargetFrameworks>
@@ -41,12 +41,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="TUnit" Version="1.43.11" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -21,19 +21,26 @@ A high-performance, thread-safe, observable collection library for .NET that com
 - [Collections](#collections)
   - [ReactiveList\<T\>](#reactivelistt)
   - [Reactive2DList\<T\>](#reactive2dlistt)
-  - [QuaternaryList\<T\>](#quaternarylistt-net-8-only)
-  - [QuaternaryDictionary\<TKey, TValue\>](#quaternarydictionarytkey-tvalue-net-8-only)
+  - [QuaternaryList\<T\>](#quaternarylistt)
+  - [QuaternaryDictionary\<TKey, TValue\>](#quaternarydictionarytkey-tvalue)
 - [Views](#views)
   - [FilteredReactiveView\<T\>](#filteredreactiveviewt)
   - [SortedReactiveView\<T\>](#sortedreactiveviewt)
   - [GroupedReactiveView\<T, TKey\>](#groupedreactiveviewt-tkey)
   - [DynamicFilteredReactiveView\<T\>](#dynamicfilteredreactiveviewt)
+  - [DynamicReactiveView\<T\>](#dynamicreactiveviewt)
   - [ReactiveView\<T\>](#reactiveviewt)
   - [Secondary Index Views](#secondary-index-views)
 - [Extension Methods Reference](#extension-methods-reference)
   - [Stream Extensions](#stream-extensions-cachenotifyextensions)
   - [ChangeSet Extensions](#changeset-extensions-reactivelistextensions)
   - [View Creation Extensions](#view-creation-extensions)
+- [API Reference](#api-reference)
+  - [Core Contracts](#core-contracts)
+  - [Core Records and Batches](#core-records-and-batches)
+  - [Collection-Specific APIs](#collection-specific-apis)
+  - [View APIs](#view-apis)
+  - [Advanced Shard APIs](#advanced-shard-apis)
 - [Real-World Examples](#real-world-examples)
   - [Live Stock Ticker](#live-stock-ticker)
   - [IoT Sensor Dashboard](#iot-sensor-dashboard)
@@ -57,8 +64,8 @@ A high-performance, thread-safe, observable collection library for .NET that com
 - **Change Sets**: Fine-grained change tracking with `ChangeSet<T>` for DynamicData-compatible processing
 - **Secondary Indices**: O(1) lookups by custom keys for high-performance filtering
 - **AOT Compatible**: Supports Native AOT on .NET 8+
-- **Cross-Platform**: Targets .NET 8, .NET 9, .NET 10, and .NET Framework 4.7.2/4.8
-- **High Performance**: QuaternaryList/Dictionary provide 6-17x faster remove operations at scale
+- **Cross-Platform**: Targets `net462`, `net472`, `net48`, `net481`, `net8.0`, `net9.0`, `net10.0`, and matching Windows TFMs
+- **High Performance**: QuaternaryList/Dictionary provide low-allocation sharded storage and outperform DynamicData in the measured large-list and dictionary benchmarks
 
 ---
 
@@ -533,16 +540,16 @@ spreadsheet.Stream.Subscribe(notification =>
 
 ---
 
-### QuaternaryList\<T\> (.NET 8+ Only)
+### QuaternaryList\<T\>
 
 A high-performance, thread-safe list that partitions elements across four internal shards for efficient concurrent access. Optimized for large datasets with frequent remove operations.
 
-> **Note:** Available only on .NET 8 and later.
+> **Target support:** Available on the .NET Framework and modern .NET target frameworks supported by the package. It is best for large sets, batch operations, secondary-index lookups, and keyed or hash-distributed workloads. For very small ordered batches, `SourceList<T>` can still be marginally faster.
 
 #### Key Advantages
 
-- **6-17x faster** remove operations compared to SourceList
-- **3-4x less memory** usage at scale
+- Faster and lower-allocation than DynamicData `SourceList<T>` for measured 1,000 and 10,000 item `AddRange` workloads
+- Much lower memory usage at scale in current benchmarks
 - Built-in **secondary indices** for O(1) lookups
 - Optimized for **parallel** operations on large datasets
 
@@ -754,16 +761,16 @@ public record Product
 
 ---
 
-### QuaternaryDictionary\<TKey, TValue\> (.NET 8+ Only)
+### QuaternaryDictionary\<TKey, TValue\>
 
 A high-performance, thread-safe dictionary that distributes key-value pairs across four internal shards for improved concurrency. Optimized for large datasets with frequent lookups and modifications.
 
-> **Note:** Available only on .NET 8 and later.
+> **Target support:** Available on the .NET Framework and modern .NET target frameworks supported by the package. It is the cache-style collection to prefer when you need key lookup, value-based secondary indices, reactive notifications, and low allocation bulk writes.
 
 #### Key Advantages
 
-- **3-5x faster** than SourceCache for bulk operations
-- **3-4x less memory** usage at scale
+- Faster and lower-allocation than DynamicData `SourceCache<TValue, TKey>` for measured `AddRange` workloads
+- Lower memory usage at each measured size in current benchmarks
 - Built-in **secondary value indices** for O(1) lookups by value properties
 - Thread-safe with fine-grained locking per shard
 
@@ -1214,6 +1221,9 @@ Extensions for working with `IObservable<CacheNotify<T>>`:
 | `ObserveOnScheduler(scheduler)` | Observe on specific scheduler | `stream.ObserveOnScheduler(Scheduler.Default)` |
 | `TransformItems(selector)` | Transform items | `stream.TransformItems(x => x.ToString())` |
 | `FilterItems(predicate)` | Filter items | `stream.FilterItems(x => x.IsValid)` |
+| `AutoDisposeBatches()` | Dispose pooled batch payloads after processing | `stream.AutoDisposeBatches()` |
+| `CountByAction()` | Project notifications to action/count tuples | `stream.CountByAction()` |
+| `ToChange()` | Convert one notification to a single change when possible | `notification.ToChange()` |
 | `ToChangeSets()` | Convert to ChangeSet stream | `stream.ToChangeSets()` |
 
 ### ChangeSet Extensions (ReactiveListExtensions)
@@ -1235,6 +1245,7 @@ Extensions for working with `IObservable<ChangeSet<T>>`:
 | `AutoRefresh(propertyName)` | Refresh on property changes | `changeSets.AutoRefresh("Price")` |
 | `AutoRefresh()` | Refresh on any property change | `changeSets.AutoRefresh()` |
 | `FilterDynamic(filterObservable)` | Dynamic filtering | `stream.FilterDynamic(filterSubject)` |
+| `WhereItems(predicate)` | Filter cache notifications by item predicate | `stream.WhereItems(x => x.IsActive)` |
 | `Connect()` | Connect to stream as ChangeSet | `source.Connect()` |
 
 ### View Creation Extensions
@@ -1256,8 +1267,316 @@ Extensions for creating views:
 | `CreateViewBySecondaryIndex(indexName, keys, scheduler, throttleMs)` | `QuaternaryList<T>` | View by multiple keys |
 | `CreateDynamicViewBySecondaryIndex(indexName, keysObservable, scheduler, throttleMs)` | `QuaternaryList<T>` | Dynamic secondary index view |
 | `CreateViewBySecondaryIndex(indexName, key, scheduler, throttleMs)` | `QuaternaryDictionary<K,V>` | Dictionary secondary index view |
+| `CreateViewBySecondaryIndex(indexName, keys, scheduler, throttleMs)` | `QuaternaryDictionary<K,V>` | Dictionary view by multiple value-index keys |
+| `CreateDynamicViewBySecondaryIndex(indexName, keysObservable, scheduler, throttleMs)` | `QuaternaryDictionary<K,V>` | Dynamic dictionary secondary index view |
 | `FilterBySecondaryIndex(list, indexName, key)` | Stream | Filter stream by index |
 | `FilterBySecondaryIndex(list, indexName, keys)` | Stream | Filter stream by multiple keys |
+| `FilterBySecondaryIndex(dict, indexName, key)` | Dictionary stream | Filter dictionary stream by value index |
+| `FilterBySecondaryIndex(dict, indexName, keys)` | Dictionary stream | Filter dictionary stream by multiple value-index keys |
+
+---
+
+## API Reference
+
+This section is the compact API map for the package. All examples assume:
+
+```csharp
+using CP.Reactive;
+using CP.Reactive.Collections;
+using CP.Reactive.Core;
+using CP.Reactive.Views;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+```
+
+### Core Contracts
+
+| Contract | Purpose | Main Members |
+|----------|---------|--------------|
+| `IReactiveSource<T>` | Common reactive source for lists, dictionaries, quaternary collections, and views over them. | `Count`, `IsReadOnly`, `Version`, `Stream`, `ToArray()`, `CollectionChanged`, `Dispose()` |
+| `IReactiveList<T>` | Ordered, UI-friendly reactive list contract. | `Items`, `ItemsAdded`, `ItemsRemoved`, `ItemsChanged`, `Added`, `Removed`, `Changed`, `CurrentItems`, `AddRange`, `InsertRange`, `RemoveRange`, `RemoveMany`, `Move`, `Update`, `ReplaceAll`, `Edit` |
+| `IQuaternaryList<T>` | Thread-safe sharded list with secondary indices. | `AddRange`, `RemoveRange`, `RemoveMany`, `ReplaceAll`, `Edit`, `AddIndex`, `GetItemsBySecondaryIndex` |
+| `IQuaternaryDictionary<TKey,TValue>` | Thread-safe sharded dictionary with value indices. | `AddOrUpdate`, `TryAdd`, `Lookup`, `AddRange`, `RemoveKeys`, `RemoveMany`, `Edit`, `AddValueIndex`, `GetValuesBySecondaryIndex`, `ValueMatchesSecondaryIndex` |
+| `IReactiveView<TView,TItem>` | Common view contract for bindable read-only views. | `Items`, `ToProperty(Action<ReadOnlyObservableCollection<TItem>>)`, `ToProperty(out ReadOnlyObservableCollection<TItem>)`, `Dispose()` |
+
+```csharp
+IReactiveSource<Order> source = new QuaternaryList<Order>();
+
+using var subscription = source.Stream
+    .CountByAction()
+    .Subscribe(change => Console.WriteLine($"{change.Action}: {change.Count}"));
+
+Console.WriteLine($"Version before edit: {source.Version}");
+```
+
+```csharp
+IReactiveList<Order> orders = new ReactiveList<Order>();
+
+orders.Added.Subscribe(batch => Console.WriteLine($"Added {batch.Count()} orders"));
+orders.CurrentItems.Subscribe(snapshot => Console.WriteLine($"Current count: {snapshot.Count()}"));
+
+orders.AddRange([new Order(1, "Open"), new Order(2, "Open")]);
+orders.Update(orders[0], orders[0] with { Status = "Packed" });
+orders.Move(oldIndex: 1, newIndex: 0);
+orders.RemoveMany(order => order.Status == "Cancelled");
+```
+
+```csharp
+IQuaternaryList<Order> indexedOrders = new QuaternaryList<Order>();
+
+indexedOrders.AddIndex("ByStatus", order => order?.Status ?? "");
+indexedOrders.AddRange([new Order(1, "Open"), new Order(2, "Closed")]);
+
+IEnumerable<Order> openOrders = indexedOrders.GetItemsBySecondaryIndex("ByStatus", "Open");
+indexedOrders.ReplaceAll(openOrders.Select(order => order with { Status = "Reviewed" }));
+```
+
+```csharp
+IQuaternaryDictionary<int, Customer> customers = new QuaternaryDictionary<int, Customer>();
+
+customers.AddValueIndex("ByRegion", customer => customer?.Region ?? "");
+customers.AddOrUpdate(42, new Customer(42, "Alice", "EMEA"));
+
+var lookup = customers.Lookup(42);
+var emeaCustomers = customers.GetValuesBySecondaryIndex("ByRegion", "EMEA");
+customers.RemoveKeys([42]);
+```
+
+```csharp
+using var activeView = orders.CreateView(order => order.Status == "Open", Scheduler.Default);
+activeView.ToProperty(out var bindableOrders);
+```
+
+### Core Records and Batches
+
+`CacheNotify<T>` is the low-level stream payload. `Action` identifies the operation, `Item` is set for single-item notifications, `Batch` is set for batch notifications, `CurrentIndex` and `PreviousIndex` describe moves or indexed list operations, and `Previous` is set for updates.
+
+```csharp
+using var sub = orders.Stream.Subscribe(notification =>
+{
+    if (notification.Action == CacheAction.Updated)
+    {
+        Console.WriteLine($"{notification.Previous} -> {notification.Item}");
+    }
+});
+```
+
+`PooledBatch<T>` wraps an array rented from `ArrayPool<T>`. If you manually handle `CacheNotify<T>.Batch`, dispose it after processing. `AutoDisposeBatches()` is the easiest way to make a stream own that lifecycle.
+
+```csharp
+using var sub = indexedOrders.Stream
+    .Do(notification =>
+    {
+        if (notification.Batch is { } batch)
+        {
+            for (var i = 0; i < batch.Count; i++)
+            {
+                Console.WriteLine(batch.Items[i]);
+            }
+        }
+    })
+    .AutoDisposeBatches()
+    .Subscribe();
+```
+
+`Change<T>` is the struct form used by DynamicData-style pipelines. Use factory methods for clarity.
+
+```csharp
+var added = Change<Order>.CreateAdd(new Order(3, "Open"), index: 0);
+var updated = Change<Order>.CreateUpdate(
+    current: new Order(3, "Closed"),
+    previous: new Order(3, "Open"),
+    index: 0);
+```
+
+`ChangeSet<T>` is an ordered batch of `Change<T>`. It exposes `Count`, `Adds`, `Removes`, `Updates`, `Moves`, an indexer, enumeration, and `AsSpan()` on supported TFMs. Dispose it when you own a manually created instance or when a downstream pipeline keeps it past immediate processing.
+
+```csharp
+using var changes = new ChangeSet<Order>([
+    Change<Order>.CreateAdd(new Order(4, "Open")),
+    Change<Order>.CreateRemove(new Order(5, "Cancelled"))
+]);
+
+foreach (var change in changes)
+{
+    Console.WriteLine($"{change.Reason}: {change.Current}");
+}
+```
+
+```csharp
+using var sub = orders.Connect().Subscribe(changeSet =>
+{
+    try
+    {
+        Console.WriteLine($"Adds={changeSet.Adds}, Removes={changeSet.Removes}");
+
+#if NET6_0_OR_GREATER
+        foreach (var change in changeSet.AsSpan())
+        {
+            Console.WriteLine(change.Current);
+        }
+#endif
+    }
+    finally
+    {
+        changeSet.Dispose();
+    }
+});
+```
+
+### Collection-Specific APIs
+
+#### ReactiveList<T>
+
+Use `ReactiveList<T>` when you need ordered list semantics, UI binding, `ReadOnlyObservableCollection<T>` projections, and familiar `IList<T>` behavior.
+
+```csharp
+var tasks = new ReactiveList<TodoItem>();
+
+tasks.CollectionChanged += (_, args) => Console.WriteLine(args.Action);
+tasks.PropertyChanged += (_, args) => Console.WriteLine(args.PropertyName);
+
+tasks.AddRange([new TodoItem("Write docs", false), new TodoItem("Run tests", false)]);
+tasks.InsertRange(1, [new TodoItem("Review benchmarks", false)]);
+tasks[0] = tasks[0] with { Done = true };
+tasks.RemoveRange(index: 1, count: 1);
+
+TodoItem[] copy = new TodoItem[tasks.Count];
+tasks.CopyTo(copy, 0);
+
+Span<TodoItem> buffer = new TodoItem[tasks.Count];
+tasks.CopyTo(buffer);
+
+IList nonGeneric = tasks;
+nonGeneric.Add(new TodoItem("Legacy IList consumer", false));
+
+tasks.Subscribe(snapshot => Console.WriteLine($"Snapshot size: {snapshot.Count()}"));
+tasks.ClearWithoutDeallocation(notifyChange: true);
+```
+
+#### Reactive2DList<T>
+
+Use `Reactive2DList<T>` for row/column style data where each row is itself a reactive list.
+
+```csharp
+var grid = new Reactive2DList<string>();
+
+grid.Add(new ReactiveList<string>(["Name", "Region"]));
+grid.Add(new ReactiveList<string>(["Alice", "EMEA"]));
+grid.SetItem(row: 1, column: 1, value: "APAC");
+grid.AddToInner(row: 0, item: "Status");
+
+IEnumerable<string> cells = grid.Flatten();
+int totalCells = grid.TotalCount();
+```
+
+#### QuaternaryList<T>
+
+`QuaternaryList<T>` distributes items across four internal shards by hash. It is not a positional list for insert/set operations; use add, remove, batch, predicate, replace, and secondary-index APIs.
+
+```csharp
+var readings = new QuaternaryList<SensorReading>();
+var selectedDeviceIds = new BehaviorSubject<string[]>(["pump-1"]);
+
+readings.AddIndex("ByDevice", reading => reading.DeviceId);
+readings.AddIndex("BySeverity", reading => reading.Severity);
+readings.AddRange(batch);
+
+var critical = readings.GetItemsBySecondaryIndex("BySeverity", Severity.Critical);
+readings.RemoveMany(reading => reading.Timestamp < cutoff);
+
+using var view = readings.CreateDynamicViewBySecondaryIndex(
+    "ByDevice",
+    selectedDeviceIds,
+    Scheduler.Default);
+```
+
+#### QuaternaryDictionary<TKey,TValue>
+
+`QuaternaryDictionary<TKey,TValue>` is the cache-style API. Use dictionary keys for identity and secondary value indices for alternative lookups.
+
+```csharp
+var sessions = new QuaternaryDictionary<string, UserSession>();
+
+sessions.AddValueIndex("ByTenant", session => session?.TenantId ?? "");
+sessions.AddRange(incoming.Select(s => KeyValuePair.Create(s.SessionId, s)));
+sessions.AddOrUpdate("abc", new UserSession("abc", "tenant-1", DateTimeOffset.UtcNow));
+
+if (sessions.TryGetValue("abc", out var session))
+{
+    Console.WriteLine(session.TenantId);
+}
+
+var tenantSessions = sessions.GetValuesBySecondaryIndex("ByTenant", "tenant-1");
+using var tenantView = sessions.CreateViewBySecondaryIndex("ByTenant", "tenant-1", Scheduler.Default);
+sessions.RemoveMany(pair => pair.Value.LastSeen < cutoff);
+```
+
+### View APIs
+
+All view types expose a read-only `Items` collection and implement `IDisposable`. Dispose views when the screen, component, or pipeline that owns them is closed.
+
+| View | Create With | Use For |
+|------|-------------|---------|
+| `FilteredReactiveView<T>` | `list.CreateView(predicate)` | Static predicate over `IReactiveList<T>` |
+| `SortedReactiveView<T>` | `list.SortBy(...)` | Sorted bindable projection |
+| `GroupedReactiveView<T,TKey>` | `list.GroupBy(keySelector)` | Bindable groups |
+| `DynamicFilteredReactiveView<T>` | `list.CreateView(filterObservable)` | Dynamic predicate over `IReactiveList<T>` |
+| `DynamicReactiveView<T>` | `source.CreateView(filterObservable)` or query overloads | Dynamic predicate over any `IReactiveSource<T>` |
+| `ReactiveView<T>` | `source.CreateView(...)` or secondary-index helpers | General source view |
+| `SecondaryIndexReactiveView<TKey,TValue,TIndexKey>` | `dict.CreateViewBySecondaryIndex(...)` | Dictionary value-index view |
+| `DynamicSecondaryIndexReactiveView<T,TKey>` | `list.CreateDynamicViewBySecondaryIndex(...)` | List secondary-index keys that change over time |
+| `DynamicSecondaryIndexDictionaryReactiveView<TKey,TValue,TIndexKey>` | `dict.CreateDynamicViewBySecondaryIndex(...)` | Dictionary value-index keys that change over time |
+
+```csharp
+var search = new BehaviorSubject<string>("");
+
+using var searchView = readings.CreateView(
+    queryObservable: search,
+    filter: (query, reading) => reading.DeviceId.Contains(query, StringComparison.OrdinalIgnoreCase),
+    scheduler: Scheduler.Default);
+
+search.OnNext("pump-");
+```
+
+```csharp
+using var grouped = tasks.GroupBy(task => task.Done ? "Done" : "Open", Scheduler.Default);
+
+if (grouped.TryGetValue("Open", out var openTasks))
+{
+    Console.WriteLine(openTasks.Count);
+}
+```
+
+### Advanced Shard APIs
+
+`QuadList<T>`, `QuadDictionary<TKey,TValue>`, `IQuad<T>`, and `QuaternaryBase<TItem,TQuad,TValue>` are public for advanced scenarios and testing, but most application code should use `QuaternaryList<T>` or `QuaternaryDictionary<TKey,TValue>`.
+
+| Type | Purpose | Notes |
+|------|---------|-------|
+| `IQuad<T>` | Minimal shard contract. | `Count`, `Clear()`, enumeration, `Dispose()` |
+| `QuadList<T>` | Pooled, non-thread-safe shard list. | Supports indexer, `Add`, `AddRange(ReadOnlySpan<T>)`, `Remove`, `RemoveAt`, `Contains`, `AsSpan()`, `Clear`, `Dispose()` |
+| `QuadDictionary<TKey,TValue>` | Pooled, non-thread-safe shard dictionary. | Supports `Add`, `TryAdd`, `TryGetValue`, `GetValueRefOrAddDefault`, `Remove`, `ContainsKey`, key/value enumeration, `EnsureCapacity`, `Dispose()` |
+| `QuaternaryBase<TItem,TQuad,TValue>` | Shared base for the quaternary collections. | Owns shards, locks, versioning, notification stream, and secondary-index storage |
+
+```csharp
+using var shard = new QuadList<int>();
+shard.AddRange([1, 2, 3]);
+
+foreach (var value in shard)
+{
+    Console.WriteLine(value);
+}
+```
+
+```csharp
+using var shard = new QuadDictionary<string, int>();
+ref var value = ref shard.GetValueRefOrAddDefault("count", out var exists);
+value = exists ? value + 1 : 1;
+```
 
 ---
 
@@ -1942,7 +2261,7 @@ list.Stream
 // For datasets > 1000 items with frequent removes
 var largeList = new QuaternaryList<DataPoint>();
 
-// 6-17x faster removes
+// Low-allocation sharded storage for large batches
 largeList.RemoveMany(dp => dp.Timestamp < cutoff);
 ```
 
@@ -1970,98 +2289,46 @@ view.Dispose();
 
 ## Benchmark Results
 
-> Benchmarks run on Windows 11, 12th Gen Intel Core i7-12650H, .NET 10.0.2
+> Benchmarks run May 4, 2026 on Windows 11, Intel Core Ultra 9 185H, .NET SDK 10.0.203, .NET 10.0.7, BenchmarkDotNet 0.15.8, ShortRun. DynamicData comparisons use `ReactiveMarbles.DynamicData`. The `SourceCache<TObject,TKey>` `AddRange` benchmark uses prebuilt `Item[]` values so object creation and LINQ projection are not charged to DynamicData.
 
-### `ReactiveList<T>` vs `SourceList<T>` (DynamicData) - .NET 10
-
-| Method | Count | Mean | Allocated |
-|--------|------:|-----:|----------:|
-| ReactiveList_AddRange | 10,000 | 602,415 ns | 3,462 KB |
-| SourceList_AddRange | 10,000 | 76,536 ns | 172.2 KB |
-| ReactiveList_Clear | 10,000 | 1,055,010 ns | 5,619 KB |
-| SourceList_Clear | 10,000 | 156,889 ns | 252.9 KB |
-| ReactiveList_Connect | 10,000 | 1,037,696 ns | 3,990 KB |
-| SourceList_Connect | 10,000 | 77,675 ns | 172.8 KB |
-| ReactiveList_RemoveMany | 10,000 | 20,227,197 ns | 5,001 KB |
-| SourceList_RemoveMany | 10,000 | 10,773,439 ns | 2,759 KB |
-
-**Summary**: SourceList is faster. ReactiveList provides fine-grained change tracking with higher overhead.
-
-### `ReactiveList<T>` vs `List<T>` - .NET 10
+### `QuaternaryList<T>` vs `SourceList<T>` AddRange
 
 | Method | Count | Mean | Allocated |
 |--------|------:|-----:|----------:|
-| List_AddRange | 10,000 | 3,821 ns | 40.1 KB |
-| ReactiveList_AddRange | 10,000 | 602,415 ns | 3,462 KB |
-| List_Clear | 10,000 | 4,036 ns | 40.1 KB |
-| ReactiveList_Clear | 10,000 | 1,055,010 ns | 5,619 KB |
-| List_Filter | 10,000 | 7,044 ns | 40.1 KB |
-| ReactiveList_Filter | 10,000 | 598,058 ns | 3,462 KB |
+| QuaternaryList_AddRange | 100 | 1,268.94 ns | 2,576 B |
+| SourceList_AddRange | 100 | 1,278.49 ns | 2,456 B |
+| QuaternaryList_AddRange | 1,000 | 3,262.75 ns | 6,160 B |
+| SourceList_AddRange | 1,000 | 9,160.45 ns | 13,296 B |
+| QuaternaryList_AddRange | 10,000 | 25,206.70 ns | 67,600 B |
+| SourceList_AddRange | 10,000 | 93,731.01 ns | 172,272 B |
 
-**Summary**: List is ~100x faster for raw operations. Use ReactiveList when you need reactive notifications.
+**Summary:** `QuaternaryList<T>` now edges `SourceList<T>` in the measured 100 item micro-batch and has wider wins at 1,000 and 10,000 items while allocating much less memory. Prefer it for larger batches, sharded workloads, secondary-index lookups, and memory-sensitive streams.
 
-### `QuaternaryList<T>` vs `SourceList<T>` (DynamicData) - .NET 10
-
-| Method | Count | Mean | Allocated |
-|--------|------:|-----:|----------:|
-| QuaternaryList_AddRange | 10,000 | 101,599 ns | 72.4 KB |
-| SourceList_AddRange | 10,000 | 77,280 ns | 172.3 KB |
-| QuaternaryList_RemoveRange | 10,000 | 1,363,441 ns | 75.1 KB |
-| SourceList_RemoveRange | 10,000 | 24,111,156 ns | 2,373 KB |
-| QuaternaryList_Remove | 10,000 | 5,243,958 ns | 72.4 KB |
-| SourceList_Remove | 10,000 | 34,751,282 ns | 1,333 KB |
-| QuaternaryList_RemoveMany | 10,000 | 1,294,411 ns | 72.4 KB |
-| SourceList_RemoveMany | 10,000 | 10,546,519 ns | 2,759 KB |
-| QuaternaryList_MixedOperations | 10,000 | 607,775 ns | 72.4 KB |
-| SourceList_MixedOperations | 10,000 | 4,500,532 ns | 1,842 KB |
-
-**Summary**: QuaternaryList is **6-17x faster** for Remove operations and uses **3-4x less memory** at scale.
-
-### `QuaternaryDictionary<TKey, TValue>` vs `SourceCache<TValue, TKey>` (DynamicData) - .NET 10
+### `QuaternaryDictionary<TKey, TValue>` vs `SourceCache<TValue, TKey>` AddRange
 
 | Method | Count | Mean | Allocated |
 |--------|------:|-----:|----------:|
-| QuaternaryDictionary_AddRange | 10,000 | 132.2 us | 327.2 KB |
-| SourceCache_AddRange | 10,000 | 602.3 us | 1,155.7 KB |
-| QuaternaryDictionary_Clear | 10,000 | 142.4 us | 327.2 KB |
-| SourceCache_Clear | 10,000 | 486.7 us | 1,155.7 KB |
-| QuaternaryDictionary_Lookup | 10,000 | 133.7 us | 327.2 KB |
-| SourceCache_Lookup | 10,000 | 302.4 us | 1,155.6 KB |
-| QuaternaryDictionary_Stream_Add | 10,000 | 180.7 us | 455.8 KB |
-| SourceCache_Stream_Add | 10,000 | 665.6 us | 2,437.8 KB |
-| QuaternaryDictionary_IterateAll | 10,000 | 220.6 us | 327.2 KB |
-| SourceCache_IterateAll | 10,000 | 349.1 us | 1,233.9 KB |
+| QuaternaryDictionary_AddRange | 100 | 2.349 us | 7.23 KB |
+| SourceCache_AddRange | 100 | 2.697 us | 10.68 KB |
+| QuaternaryDictionary_AddRange | 1,000 | 10.413 us | 42.23 KB |
+| SourceCache_AddRange | 1,000 | 25.070 us | 100.55 KB |
+| QuaternaryDictionary_AddRange | 10,000 | 80.972 us | 322.24 KB |
+| SourceCache_AddRange | 10,000 | 545.788 us | 920.76 KB |
 
-**Summary**: QuaternaryDictionary is **3-5x faster** and uses **3-4x less memory** than SourceCache at scale.
-
-### `QuaternaryDictionary<TKey, TValue>` vs `Dictionary<TKey, TValue>` - .NET 10
-
-| Method | Count | Mean | Allocated |
-|--------|------:|-----:|----------:|
-| Dictionary_AddRange | 10,000 | 235.9 us | 657.6 KB |
-| QuaternaryDictionary_AddRange | 10,000 | 132.2 us | 327.2 KB |
-| Dictionary_Clear | 10,000 | 113.3 us | 197.5 KB |
-| QuaternaryDictionary_Clear | 10,000 | 142.4 us | 327.2 KB |
-| Dictionary_TryGetValue | 10,000 | 91.9 us | 197.5 KB |
-| QuaternaryDictionary_TryGetValue | 10,000 | 134.3 us | 327.2 KB |
-| Dictionary_IterateAll | 10,000 | 87.1 us | 197.5 KB |
-| QuaternaryDictionary_IterateAll | 10,000 | 220.6 us | 327.2 KB |
-
-**Summary**: Dictionary is faster for raw operations. QuaternaryDictionary is **1.8x faster for bulk AddRange** and adds thread-safety, reactive notifications, and secondary indices.
+**Summary:** `QuaternaryDictionary<TKey,TValue>` is faster and allocates less memory than `SourceCache<TValue,TKey>` at every measured size. Prefer it when you need a thread-safe reactive cache with bulk writes, key lookup, and optional value-based secondary indices.
 
 ### When to Use Which Collection
 
 | Scenario | Recommendation |
 |----------|---------------|
-| Small datasets (<1,000 items) | `ReactiveList<T>` |
-| Large datasets with frequent removes | `QuaternaryList<T>` **(6-17x faster)** |
-| Large key-value datasets | `QuaternaryDictionary<TKey,TValue>` **(3-5x faster)** |
-| Memory-constrained environments | `QuaternaryList/Dictionary` **(3-4x less memory)** |
-| Rich LINQ operators needed | DynamicData `SourceList<T>` / `SourceCache<TValue, TKey>` |
-| Secondary indices for O(1) lookups | `QuaternaryList<T>` / `QuaternaryDictionary<TKey,TValue>` |
-| Thread-safe concurrent access | All ReactiveList collections |
-| 2D/Matrix data structures | `Reactive2DList<T>` |
-| .NET Framework 4.7.2/4.8 | `ReactiveList<T>` / `Reactive2DList<T>` |
+| Ordered, UI-bound lists with familiar `IList<T>` behavior | `ReactiveList<T>` |
+| Two-dimensional row/column data | `Reactive2DList<T>` |
+| Small ordered batches where DynamicData operators are already central | DynamicData `SourceList<T>` |
+| Large list batches, frequent removes, secondary-index lookups, or lower allocation pressure | `QuaternaryList<T>` |
+| Key-value cache workloads with bulk writes and value indices | `QuaternaryDictionary<TKey,TValue>` |
+| Rich DynamicData operator graph already required | DynamicData `SourceList<T>` / `SourceCache<TValue,TKey>` |
+| Thread-safe concurrent access with reactive notifications | All ReactiveList collections |
+| .NET Framework `net462`, `net472`, `net48`, or `net481` | `ReactiveList<T>`, `Reactive2DList<T>`, `QuaternaryList<T>`, `QuaternaryDictionary<TKey,TValue>` |
 
 ---
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/ReactiveList.Benchmarks/ListBenchmarks.cs
+++ b/src/ReactiveList.Benchmarks/ListBenchmarks.cs
@@ -127,7 +127,7 @@ public class ListBenchmarks
     {
         using var list = new SourceList<int>();
         var total = 0;
-        using var sub = list.Connect().Subscribe(_ => total++);
+        using var sub = list.Connect().Subscribe(changes => total += changes.TotalChanges);
         list.AddRange(_data);
         return total;
     }
@@ -169,8 +169,27 @@ public class ListBenchmarks
     {
         using var list = new SourceList<int>();
         var total = 0;
-        using var sub = list.Connect().Subscribe(changes => total += changes.Count);
+        using var sub = list.Connect().Subscribe(changes => total += changes.TotalChanges);
         list.AddRange(_data);
+        return total;
+    }
+
+    [Benchmark]
+    public int ReactiveList_Connect_Preloaded()
+    {
+        using var list = new ReactiveList<int>(_data);
+        var total = 0;
+        using var sub = list.Connect().Subscribe(changes => total += changes.Count);
+        return total;
+    }
+
+    [Benchmark]
+    public int SourceList_Connect_Preloaded()
+    {
+        using var list = new SourceList<int>();
+        list.AddRange(_data);
+        var total = 0;
+        using var sub = list.Connect().Subscribe(changes => total += changes.TotalChanges);
         return total;
     }
 
@@ -218,7 +237,8 @@ public class ListBenchmarks
     public int ReactiveList_RemoveMany()
     {
         using var list = new ReactiveList<int>(_data);
-        return list.RemoveMany(x => x % 2 == 0);
+        list.RemoveMany(x => x % 2 == 0);
+        return list.Count;
     }
 
     [Benchmark]

--- a/src/ReactiveList.Benchmarks/QuaternaryDictionaryBenchmarks.cs
+++ b/src/ReactiveList.Benchmarks/QuaternaryDictionaryBenchmarks.cs
@@ -12,6 +12,7 @@ public class QuaternaryDictionaryBenchmarks
     public int Count { get; set; }
 
     private KeyValuePair<int, int>[] _kvps = [];
+    private Item[] _items = [];
 
     [GlobalSetup]
     public void Setup()
@@ -19,6 +20,7 @@ public class QuaternaryDictionaryBenchmarks
         _kvps = Enumerable.Range(0, Count)
             .Select(i => new KeyValuePair<int, int>(i, i))
             .ToArray();
+        _items = _kvps.Select(k => new Item(k.Key, k.Value)).ToArray();
     }
 
     [Benchmark]
@@ -45,7 +47,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_AddRange()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         return cache.Count;
     }
 
@@ -78,7 +80,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_Remove()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         cache.RemoveKeys(Enumerable.Range(0, Count / 2));
         return cache.Count;
     }
@@ -113,7 +115,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_Clear()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         cache.Clear();
         return cache.Count;
     }
@@ -145,7 +147,7 @@ public class QuaternaryDictionaryBenchmarks
     public bool SourceCache_Lookup()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         return cache.Lookup(Count - 1).HasValue;
     }
 
@@ -165,7 +167,7 @@ public class QuaternaryDictionaryBenchmarks
         using var cache = new SourceCache<Item, int>(x => x.Id);
         var events = 0;
         using var sub = cache.Connect().Subscribe(_ => events++);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         return events;
     }
 
@@ -189,7 +191,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_Edit()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         cache.Edit(innerCache =>
         {
             innerCache.Clear();
@@ -206,7 +208,8 @@ public class QuaternaryDictionaryBenchmarks
     {
         using var dict = new QuaternaryDictionary<int, int>();
         dict.AddRange(_kvps);
-        return dict.RemoveMany(kvp => kvp.Key % 2 == 0);
+        dict.RemoveMany(kvp => kvp.Key % 2 == 0);
+        return dict.Count;
     }
 
     [Benchmark]
@@ -394,7 +397,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_Keys()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         return cache.Keys.ToList().Count;
     }
 
@@ -409,7 +412,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_Values()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         return cache.Items.ToList().Count;
     }
 
@@ -417,7 +420,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_IterateAll()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         var sum = 0;
         foreach (var item in cache.Items)
         {
@@ -442,7 +445,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_Stream_Remove()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         var events = 0;
         using var sub = cache.Connect().Subscribe(_ => events++);
         cache.RemoveKeys(Enumerable.Range(0, Count / 2));
@@ -518,7 +521,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_Count()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         return cache.Count;
     }
 
@@ -537,7 +540,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_MixedOperations()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         cache.AddOrUpdate(new Item(Count, Count));
         cache.Remove(0);
         cache.RemoveKeys(cache.Keys.Where(k => k % 10 == 0));
@@ -658,7 +661,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_RemoveKeys()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         cache.RemoveKeys(Enumerable.Range(0, Count / 2));
         return cache.Count;
     }
@@ -667,7 +670,7 @@ public class QuaternaryDictionaryBenchmarks
     public int SourceCache_RemoveMany()
     {
         using var cache = new SourceCache<Item, int>(x => x.Id);
-        cache.AddOrUpdate(_kvps.Select(k => new Item(k.Key, k.Value)));
+        cache.AddOrUpdate(_items);
         cache.RemoveKeys(cache.Keys.Where(k => k % 2 == 0));
         return cache.Count;
     }

--- a/src/ReactiveList.Benchmarks/QuaternaryListBenchmarks.cs
+++ b/src/ReactiveList.Benchmarks/QuaternaryListBenchmarks.cs
@@ -217,7 +217,8 @@ public class QuaternaryListBenchmarks
     {
         using var list = new QuaternaryList<int>();
         list.AddRange(_data);
-        return list.RemoveMany(x => x % 2 == 0);
+        list.RemoveMany(x => x % 2 == 0);
+        return list.Count;
     }
 
     [Benchmark]

--- a/src/ReactiveList.Test/Assert.cs
+++ b/src/ReactiveList.Test/Assert.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ReactiveList.Test;
+
+internal static class Assert
+{
+    public static void All<T>(IEnumerable<T> collection, Action<T> assertion)
+    {
+        foreach (var item in collection)
+        {
+            assertion(item);
+        }
+    }
+
+    public static void Contains<T>(T expected, IEnumerable<T> collection)
+    {
+        if (!collection.Contains(expected))
+        {
+            throw new InvalidOperationException($"Expected collection to contain {expected}.");
+        }
+    }
+
+    public static void Contains<T>(IEnumerable<T> collection, Predicate<T> predicate)
+    {
+        if (!collection.Any(item => predicate(item)))
+        {
+            throw new InvalidOperationException("Expected collection to contain a matching item.");
+        }
+    }
+
+    public static void DoesNotContain<T>(T expected, IEnumerable<T> collection)
+    {
+        if (collection.Contains(expected))
+        {
+            throw new InvalidOperationException($"Expected collection not to contain {expected}.");
+        }
+    }
+
+    public static void DoesNotContain<T>(IEnumerable<T> collection, Predicate<T> predicate)
+    {
+        if (collection.Any(item => predicate(item)))
+        {
+            throw new InvalidOperationException("Expected collection not to contain a matching item.");
+        }
+    }
+
+    public static void Empty(IEnumerable collection)
+    {
+        if (collection.GetEnumerator().MoveNext())
+        {
+            throw new InvalidOperationException("Expected collection to be empty.");
+        }
+    }
+
+    public static void Equal<T>(T expected, T actual)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException($"Expected {expected}, but found {actual}.");
+        }
+    }
+
+    public static void False(bool condition)
+    {
+        if (condition)
+        {
+            throw new InvalidOperationException("Expected condition to be false.");
+        }
+    }
+
+    public static T NotNull<T>(T? value)
+    {
+        if (value is null)
+        {
+            throw new InvalidOperationException("Expected value not to be null.");
+        }
+
+        return value;
+    }
+
+    public static T Single<T>(IEnumerable<T> collection)
+    {
+        using var enumerator = collection.GetEnumerator();
+        if (!enumerator.MoveNext())
+        {
+            throw new InvalidOperationException("Expected exactly one item, but the collection was empty.");
+        }
+
+        var item = enumerator.Current;
+        if (enumerator.MoveNext())
+        {
+            throw new InvalidOperationException("Expected exactly one item, but the collection contained multiple items.");
+        }
+
+        return item;
+    }
+
+    public static T Throws<T>(Action action)
+        where T : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (T exception)
+        {
+            return exception;
+        }
+
+        throw new InvalidOperationException($"Expected exception of type {typeof(T).Name}.");
+    }
+
+    public static void True(bool condition)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException("Expected condition to be true.");
+        }
+    }
+}

--- a/src/ReactiveList.Test/CacheActionTests.cs
+++ b/src/ReactiveList.Test/CacheActionTests.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETFRAMEWORK
 using System;
+using System.Linq;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -17,7 +18,7 @@ public class CacheActionTests
     /// <summary>
     /// CacheAction should have correct values.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheAction_ShouldHaveCorrectValues()
     {
         ((int)CacheAction.Added).Should().Be(0);
@@ -34,10 +35,10 @@ public class CacheActionTests
     /// <summary>
     /// All CacheAction values should be defined.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheAction_AllValuesShouldBeDefined()
     {
-        var values = Enum.GetValues<CacheAction>();
+        var values = Enum.GetValues(typeof(CacheAction)).Cast<CacheAction>().ToArray();
 
         values.Should().HaveCount(9);
         values.Should().Contain(CacheAction.Added);

--- a/src/ReactiveList.Test/CacheNotifyTests.cs
+++ b/src/ReactiveList.Test/CacheNotifyTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Buffers;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -17,7 +17,7 @@ public class CacheNotifyTests
     /// <summary>
     /// Constructor should initialize Action and Item.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithActionAndItem_ShouldInitialize()
     {
         var notify = new CacheNotify<string>(CacheAction.Added, "test");
@@ -30,7 +30,7 @@ public class CacheNotifyTests
     /// <summary>
     /// Constructor should initialize with batch.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithBatch_ShouldInitialize()
     {
         var array = ArrayPool<int>.Shared.Rent(10);
@@ -50,7 +50,7 @@ public class CacheNotifyTests
     /// <summary>
     /// Constructor with null item should be valid.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithNullItem_ShouldBeValid()
     {
         var notify = new CacheNotify<string>(CacheAction.Cleared, null);
@@ -62,7 +62,7 @@ public class CacheNotifyTests
     /// <summary>
     /// Record equality should work correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void RecordEquality_ShouldWorkCorrectly()
     {
         var notify1 = new CacheNotify<string>(CacheAction.Added, "test");
@@ -75,7 +75,7 @@ public class CacheNotifyTests
     /// <summary>
     /// Record inequality for different actions.
     /// </summary>
-    [Fact]
+    [Test]
     public void RecordInequality_DifferentActions_ShouldNotBeEqual()
     {
         var notify1 = new CacheNotify<string>(CacheAction.Added, "test");
@@ -88,7 +88,7 @@ public class CacheNotifyTests
     /// <summary>
     /// Record inequality for different items.
     /// </summary>
-    [Fact]
+    [Test]
     public void RecordInequality_DifferentItems_ShouldNotBeEqual()
     {
         var notify1 = new CacheNotify<string>(CacheAction.Added, "test1");
@@ -100,7 +100,7 @@ public class CacheNotifyTests
     /// <summary>
     /// CacheNotify for Added action.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheNotify_AddedAction_ShouldHaveCorrectState()
     {
         var notify = new CacheNotify<int>(CacheAction.Added, 42);
@@ -112,7 +112,7 @@ public class CacheNotifyTests
     /// <summary>
     /// CacheNotify for Removed action.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheNotify_RemovedAction_ShouldHaveCorrectState()
     {
         var notify = new CacheNotify<int>(CacheAction.Removed, 42);
@@ -124,7 +124,7 @@ public class CacheNotifyTests
     /// <summary>
     /// CacheNotify for Updated action.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheNotify_UpdatedAction_ShouldHaveCorrectState()
     {
         var notify = new CacheNotify<string>(CacheAction.Updated, "updated");
@@ -136,7 +136,7 @@ public class CacheNotifyTests
     /// <summary>
     /// CacheNotify for Cleared action.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheNotify_ClearedAction_ShouldHaveCorrectState()
     {
         var notify = new CacheNotify<string>(CacheAction.Cleared, null);
@@ -148,7 +148,7 @@ public class CacheNotifyTests
     /// <summary>
     /// CacheNotify for BatchOperation action.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheNotify_BatchOperationAction_ShouldHaveCorrectState()
     {
         var array = ArrayPool<string>.Shared.Rent(10);
@@ -168,7 +168,7 @@ public class CacheNotifyTests
     /// <summary>
     /// CacheNotify with expression should work.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheNotify_WithExpression_ShouldWork()
     {
         var notify1 = new CacheNotify<int>(CacheAction.Added, 10);
@@ -182,7 +182,7 @@ public class CacheNotifyTests
     /// <summary>
     /// GetHashCode should be consistent.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetHashCode_ShouldBeConsistent()
     {
         var notify = new CacheNotify<string>(CacheAction.Added, "test");
@@ -196,7 +196,7 @@ public class CacheNotifyTests
     /// <summary>
     /// ToString should return meaningful representation.
     /// </summary>
-    [Fact]
+    [Test]
     public void ToString_ShouldReturnMeaningfulRepresentation()
     {
         var notify = new CacheNotify<string>(CacheAction.Added, "test");
@@ -211,7 +211,7 @@ public class CacheNotifyTests
     /// <summary>
     /// CacheNotify with value types.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheNotify_WithValueTypes_ShouldWork()
     {
         var notify = new CacheNotify<DateTime>(CacheAction.Added, DateTime.Today);
@@ -222,7 +222,7 @@ public class CacheNotifyTests
     /// <summary>
     /// CacheNotify with complex types.
     /// </summary>
-    [Fact]
+    [Test]
     public void CacheNotify_WithComplexTypes_ShouldWork()
     {
         var person = new { Id = 1, Name = "John" };

--- a/src/ReactiveList.Test/CoreCoverageTests.cs
+++ b/src/ReactiveList.Test/CoreCoverageTests.cs
@@ -1,0 +1,465 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using CP.Reactive.Core;
+using CP.Reactive.Internal;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace ReactiveList.Test;
+
+/// <summary>
+/// Additional coverage tests for core reactive primitives.
+/// </summary>
+public class CoreCoverageTests
+{
+    /// <summary>
+    /// Cache notification stream extensions should filter, project, and count notifications.
+    /// </summary>
+    [Test]
+    public void CacheNotifyExtensions_ShouldFilterProjectAndCountNotifications()
+    {
+        using var subject = new Subject<CacheNotify<string>>();
+        var whereAction = new List<CacheNotify<string>>();
+        var whereAdded = new List<CacheNotify<string>>();
+        var whereRemoved = new List<CacheNotify<string>>();
+        var selectedItems = new List<string>();
+        var allItems = new List<string>();
+        var addedItems = new List<string>();
+        var removedItems = new List<string>();
+        var updatedItems = new List<string>();
+        var movedItems = new List<(string Item, int OldIndex, int NewIndex)>();
+        var cleared = new List<CacheNotify<string>>();
+        var transformed = new List<string>();
+        var filtered = new List<string>();
+        var counts = new List<(CacheAction Action, int Count)>();
+
+        using var whereActionSubscription = subject.WhereAction(CacheAction.Added).Subscribe(whereAction.Add);
+        using var whereAddedSubscription = subject.WhereAdded().Subscribe(whereAdded.Add);
+        using var whereRemovedSubscription = subject.WhereRemoved().Subscribe(whereRemoved.Add);
+        using var selectedSubscription = subject.SelectItems().Subscribe(selectedItems.Add);
+        using var allSubscription = subject.SelectAllItems().Subscribe(allItems.Add);
+        using var addedSubscription = subject.OnItemAdded().Subscribe(addedItems.Add);
+        using var removedSubscription = subject.OnItemRemoved().Subscribe(removedItems.Add);
+        using var updatedSubscription = subject.OnItemUpdated().Subscribe(updatedItems.Add);
+        using var movedSubscription = subject.OnItemMoved().Subscribe(movedItems.Add);
+        using var clearedSubscription = subject.OnCleared().Subscribe(cleared.Add);
+        using var transformedSubscription = subject.TransformItems(item => item.ToUpperInvariant()).Subscribe(transformed.Add);
+        using var filteredSubscription = subject.FilterItems(item => item.Contains("o")).Subscribe(filtered.Add);
+        using var countSubscription = subject.CountByAction().Subscribe(counts.Add);
+
+        var addedBatch = CreateStringBatch("two", "four");
+        var removedBatch = CreateStringBatch("eight", "ten");
+
+        subject.OnNext(new CacheNotify<string>(CacheAction.Added, "one", CurrentIndex: 0));
+        subject.OnNext(new CacheNotify<string>(CacheAction.BatchAdded, default, addedBatch, CurrentIndex: 1));
+        subject.OnNext(new CacheNotify<string>(CacheAction.Removed, "six", CurrentIndex: 2));
+        subject.OnNext(new CacheNotify<string>(CacheAction.BatchRemoved, default, removedBatch));
+        subject.OnNext(new CacheNotify<string>(CacheAction.Updated, "twelve", CurrentIndex: 3, Previous: "eleven"));
+        subject.OnNext(new CacheNotify<string>(CacheAction.Moved, "fourteen", CurrentIndex: 4, PreviousIndex: 2));
+        subject.OnNext(new CacheNotify<string>(CacheAction.Cleared, default));
+        subject.OnNext(new CacheNotify<string>(CacheAction.BatchOperation, default));
+
+        whereAction.Should().ContainSingle()
+            .Which.Item.Should().Be("one");
+        whereAdded.Select(notification => notification.Action).Should().Equal(CacheAction.Added, CacheAction.BatchAdded);
+        whereRemoved.Select(notification => notification.Action).Should().Equal(CacheAction.Removed, CacheAction.BatchRemoved);
+        selectedItems.Should().Equal("one", "six", "twelve", "fourteen");
+        allItems.Should().Equal("one", "two", "four", "six", "eight", "ten", "twelve", "fourteen");
+        addedItems.Should().Equal("one", "two", "four");
+        removedItems.Should().Equal("six", "eight", "ten");
+        updatedItems.Should().Equal("twelve");
+        movedItems.Should().Equal(("fourteen", 2, 4));
+        cleared.Should().ContainSingle();
+        transformed.Should().Equal("ONE", "TWO", "FOUR", "SIX", "EIGHT", "TEN", "TWELVE", "FOURTEEN");
+        filtered.Should().Equal("one", "two", "four", "fourteen");
+        counts.Select(item => item.Count).Should().Equal(1, 2, 1, 2, 1, 1, 0, 0);
+
+        addedBatch.Dispose();
+        removedBatch.Dispose();
+    }
+
+    /// <summary>
+    /// Time and scheduler extensions should buffer, throttle, observe, and dispose batches.
+    /// </summary>
+    [Test]
+    public void CacheNotifyExtensions_ShouldBufferThrottleObserveAndDisposeBatches()
+    {
+        var notification = new CacheNotify<int>(CacheAction.Added, 1);
+        var buffered = new[] { notification }.ToObservable()
+            .BufferNotifications(TimeSpan.FromMilliseconds(1))
+            .ToEnumerable()
+            .ToList();
+        var emptyBuffered = Array.Empty<CacheNotify<int>>().ToObservable()
+            .BufferNotifications(TimeSpan.FromMilliseconds(1))
+            .ToEnumerable()
+            .ToList();
+        var throttled = new[] { notification }.ToObservable()
+            .ThrottleNotifications(TimeSpan.Zero)
+            .ToEnumerable()
+            .ToList();
+        var observed = new[] { notification }.ToObservable()
+            .ObserveOnScheduler(ImmediateScheduler.Instance)
+            .ToEnumerable()
+            .ToList();
+
+        buffered.Should().ContainSingle()
+            .Which.Should().ContainSingle()
+            .Which.Should().BeSameAs(notification);
+        emptyBuffered.Should().BeEmpty();
+        throttled.Should().ContainSingle()
+            .Which.Should().BeSameAs(notification);
+        observed.Should().ContainSingle()
+            .Which.Should().BeSameAs(notification);
+
+        using var subject = new Subject<CacheNotify<int>>();
+        var autoDisposed = new List<CacheNotify<int>>();
+        using var subscription = subject.AutoDisposeBatches().Subscribe(autoDisposed.Add);
+        var batch = CreateBatch(42);
+
+        subject.OnNext(new CacheNotify<int>(CacheAction.BatchAdded, default, batch));
+        Action disposeAgain = () => batch.Dispose();
+
+        autoDisposed.Should().ContainSingle();
+        disposeAgain.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// CacheNotifyExtensions should validate null arguments.
+    /// </summary>
+    [Test]
+    public void CacheNotifyExtensions_ShouldValidateNullArguments()
+    {
+        IObservable<CacheNotify<int>> source = null!;
+        var valid = new[] { new CacheNotify<int>(CacheAction.Added, 1) }.ToObservable();
+
+        Action[] sourceActions =
+        [
+            () => source.WhereAction(CacheAction.Added),
+            () => source.WhereAdded(),
+            () => source.WhereRemoved(),
+            () => source.SelectItems(),
+            () => source.SelectAllItems(),
+            () => source.OnItemMoved(),
+            () => source.BufferNotifications(TimeSpan.FromMilliseconds(1)),
+            () => source.ThrottleNotifications(TimeSpan.FromMilliseconds(1)),
+            () => source.ObserveOnScheduler(ImmediateScheduler.Instance),
+            () => source.TransformItems(item => item),
+            () => source.FilterItems(item => true),
+            () => source.AutoDisposeBatches(),
+            () => source.CountByAction(),
+            () => source.ToChangeSets()
+        ];
+
+        foreach (var action in sourceActions)
+        {
+            action.Should().Throw<ArgumentNullException>()
+                .WithParameterName("source");
+        }
+
+        Action observeNullScheduler = () => valid.ObserveOnScheduler(null!);
+        Action transformNullSelector = () => valid.TransformItems<int, int>(null!);
+        Action filterNullPredicate = () => valid.FilterItems(null!);
+
+        observeNullScheduler.Should().Throw<ArgumentNullException>()
+            .WithParameterName("scheduler");
+        transformNullSelector.Should().Throw<ArgumentNullException>()
+            .WithParameterName("selector");
+        filterNullPredicate.Should().Throw<ArgumentNullException>()
+            .WithParameterName("predicate");
+    }
+
+    /// <summary>
+    /// ToChange should map single notifications and ignore unsupported ones.
+    /// </summary>
+    [Test]
+    public void ToChange_ShouldMapSingleNotifications()
+    {
+        CacheNotify<int> nullNotification = null!;
+
+        nullNotification.ToChange().Should().BeNull();
+        new CacheNotify<int>(CacheAction.Added, 1, CurrentIndex: 2).ToChange().Should().Be(
+            Change<int>.CreateAdd(1, 2));
+        new CacheNotify<int>(CacheAction.Removed, 3, CurrentIndex: 4).ToChange().Should().Be(
+            Change<int>.CreateRemove(3, 4));
+        new CacheNotify<int>(CacheAction.Updated, 5, CurrentIndex: 6, Previous: 4).ToChange().Should().Be(
+            Change<int>.CreateUpdate(5, 4, 6));
+        new CacheNotify<int>(CacheAction.Moved, 7, CurrentIndex: 8, PreviousIndex: 9).ToChange().Should().Be(
+            Change<int>.CreateMove(7, 8, 9));
+        new CacheNotify<int>(CacheAction.Refreshed, 10, CurrentIndex: 11).ToChange().Should().Be(
+            Change<int>.CreateRefresh(10, 11));
+
+        var clearChange = new CacheNotify<int>(CacheAction.Cleared, default).ToChange();
+        clearChange.Should().NotBeNull();
+        clearChange!.Value.Reason.Should().Be(ChangeReason.Clear);
+
+        new CacheNotify<int>(CacheAction.BatchAdded, default).ToChange().Should().BeNull();
+        new CacheNotify<string>(CacheAction.Added, default).ToChange().Should().BeNull();
+    }
+
+    /// <summary>
+    /// ToChangeSets should expand batches, singles, and filter empty changes.
+    /// </summary>
+    [Test]
+    public void ToChangeSets_ShouldExpandBatchesSinglesAndFilterEmptyChanges()
+    {
+        var addedBatch = CreateBatch(1, 2);
+        var removedBatch = CreateBatch(3, 4);
+        var clearedBatch = CreateBatch(5);
+        var refreshBatch = CreateBatch(6);
+        var emptyBatch = new PooledBatch<int>(ArrayPool<int>.Shared.Rent(1), 0);
+
+        var notifications = new[]
+        {
+            new CacheNotify<int>(CacheAction.BatchAdded, default, addedBatch, CurrentIndex: 10),
+            new CacheNotify<int>(CacheAction.BatchRemoved, default, removedBatch),
+            new CacheNotify<int>(CacheAction.Cleared, default, clearedBatch),
+            new CacheNotify<int>(CacheAction.BatchOperation, default, refreshBatch),
+            new CacheNotify<int>(CacheAction.Cleared, default),
+            new CacheNotify<int>(CacheAction.BatchAdded, default, emptyBatch),
+            new CacheNotify<int>(CacheAction.Added, 7, CurrentIndex: 20),
+            new CacheNotify<int>(CacheAction.BatchRemoved, default)
+        };
+
+        var changeSets = notifications.ToObservable()
+            .ToChangeSets()
+            .ToEnumerable()
+            .ToList();
+
+        changeSets.Should().HaveCount(5);
+        changeSets[0].Should().HaveCount(2);
+        changeSets[0].Select(change => change.Reason).Should().AllBeEquivalentTo(ChangeReason.Add);
+        changeSets[0][0].CurrentIndex.Should().Be(10);
+        changeSets[1].Select(change => change.Reason).Should().AllBeEquivalentTo(ChangeReason.Remove);
+        changeSets[2].Should().ContainSingle()
+            .Which.Reason.Should().Be(ChangeReason.Remove);
+        changeSets[3].Should().ContainSingle()
+            .Which.Reason.Should().Be(ChangeReason.Refresh);
+        changeSets[4].Should().ContainSingle()
+            .Which.Should().Be(Change<int>.CreateAdd(7, 20));
+
+        foreach (var changeSet in changeSets)
+        {
+            changeSet.Dispose();
+        }
+
+        addedBatch.Dispose();
+        removedBatch.Dispose();
+        clearedBatch.Dispose();
+        refreshBatch.Dispose();
+        emptyBatch.Dispose();
+    }
+
+    /// <summary>
+    /// ChangeSet should expose counts, spans, enumerators, and validation.
+    /// </summary>
+    [Test]
+    public void ChangeSet_ShouldExposeCountsEnumeratorsAndValidation()
+    {
+        var changes = new[]
+        {
+            Change<int>.CreateAdd(1, 0),
+            Change<int>.CreateRemove(2, 1),
+            Change<int>.CreateUpdate(3, 2, 2),
+            Change<int>.CreateMove(4, 3, 0)
+        };
+
+        using var set = new ChangeSet<int>(changes);
+        using var single = new ChangeSet<int>(Change<int>.CreateRefresh(5, 4));
+        using var comparison = new ChangeSet<int>(changes.ToArray());
+        var defaultSet = default(ChangeSet<int>);
+
+        set.Count.Should().Be(4);
+        set.Adds.Should().Be(1);
+        set.Removes.Should().Be(1);
+        set.Updates.Should().Be(1);
+        set.Moves.Should().Be(1);
+        set[0].Should().Be(changes[0]);
+        single.Should().ContainSingle()
+            .Which.Should().Be(Change<int>.CreateRefresh(5, 4));
+        defaultSet.Adds.Should().Be(0);
+        set.Equals(set).Should().BeTrue();
+        set.Equals(comparison).Should().BeFalse();
+        set.GetHashCode().Should().NotBe(0);
+
+        ((IEnumerable<Change<int>>)set).Select(change => change.Current).Should().Equal(1, 2, 3, 4);
+
+        var enumerator = ((IEnumerable)set).GetEnumerator();
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Should().Be(changes[0]);
+        enumerator.Reset();
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Should().Be(changes[0]);
+
+        Action getNegative = () => _ = set[-1];
+        Action getPastEnd = () => _ = set[set.Count];
+        Action createNull = () => _ = new ChangeSet<int>(null!);
+
+        getNegative.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("index");
+        getPastEnd.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("index");
+        createNull.Should().Throw<ArgumentNullException>()
+            .WithParameterName("changes");
+
+#if NET6_0_OR_GREATER
+        using var spanSet = new ChangeSet<int>(changes.AsSpan());
+        spanSet.AsSpan().ToArray().Should().Equal(changes);
+#endif
+    }
+
+    /// <summary>
+    /// PooledEditableListWrapper should synchronize all list operations.
+    /// </summary>
+    [Test]
+    public void PooledEditableListWrapper_ShouldSynchronizeOperationsAndValidateMoves()
+    {
+        EditableListWrapperPool<string>.Clear();
+        var list = new List<string> { "one", "two" };
+        var observable = new ObservableCollection<string>(list);
+        using var wrapper = new PooledEditableListWrapper<string>(list, observable);
+
+        wrapper.IsReadOnly.Should().BeFalse();
+        wrapper[1].Should().Be("two");
+        wrapper[1] = "deux";
+        wrapper.AddRange(["three", "four"]);
+        wrapper.Insert(1, "inserted");
+        wrapper.Move(0, 2);
+        wrapper.Move(2, 2);
+
+        list.Should().Equal("inserted", "deux", "one", "three", "four");
+        observable.Should().Equal(list);
+        wrapper.Contains("three").Should().BeTrue();
+        wrapper.IndexOf("three").Should().Be(3);
+
+        var copied = new string[wrapper.Count];
+        wrapper.CopyTo(copied, 0);
+        copied.Should().Equal(list);
+        wrapper.ToArray().Should().Equal(list);
+        ((IEnumerable)wrapper).Cast<string>().Should().Equal(list);
+        var wrapperEnumerator = ((IEnumerable)wrapper).GetEnumerator();
+        wrapperEnumerator.MoveNext().Should().BeTrue();
+        wrapperEnumerator.Current.Should().Be("inserted");
+
+        wrapper.Remove("missing").Should().BeFalse();
+        wrapper.Remove("deux").Should().BeTrue();
+        wrapper.RemoveAt(0);
+        wrapper.Clear();
+
+        list.Should().BeEmpty();
+        observable.Should().BeEmpty();
+
+        wrapper.Initialize(new List<string> { "a", "b" }, null);
+        wrapper.Count.Should().Be(2);
+
+        Action badOldIndex = () => wrapper.Move(-1, 0);
+        Action badNewIndex = () => wrapper.Move(0, 2);
+
+        badOldIndex.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("oldIndex");
+        badNewIndex.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("newIndex");
+
+        EditableListWrapperPool<string>.Clear();
+    }
+
+    /// <summary>
+    /// Returned pooled wrappers should reject future access and dispose idempotently.
+    /// </summary>
+    [Test]
+    public void PooledEditableListWrapper_WhenReturned_ShouldRejectAccessAndDisposeIdempotently()
+    {
+        EditableListWrapperPool<int>.Clear();
+        var wrapper = new PooledEditableListWrapper<int>([]);
+
+        ((IResettable)wrapper).Reset();
+        wrapper.Dispose();
+
+        wrapper.Count.Should().Be(0);
+        Action useReturned = () => wrapper.Add(1);
+
+        useReturned.Should().Throw<ObjectDisposedException>();
+    }
+
+    /// <summary>
+    /// ReactiveGroup should expose grouping data and forward collection change events.
+    /// </summary>
+    [Test]
+    public void ReactiveGroup_ShouldExposeItemsAndForwardCollectionChanges()
+    {
+        var source = new ObservableCollection<string>(["one"]);
+        var group = new ReactiveGroup<string, string>("letters", source);
+        var events = new List<NotifyCollectionChangedEventArgs>();
+        group.CollectionChanged += (sender, args) => events.Add(args);
+
+        source.Add("two");
+
+        group.Key.Should().Be("letters");
+        group.Count.Should().Be(2);
+        group.Items.Should().Equal("one", "two");
+        group.Should().Equal("one", "two");
+        ((IEnumerable)group).Cast<string>().Should().Equal("one", "two");
+        var groupEnumerator = ((IEnumerable)group).GetEnumerator();
+        groupEnumerator.MoveNext().Should().BeTrue();
+        groupEnumerator.Current.Should().Be("one");
+        events.Should().ContainSingle()
+            .Which.Action.Should().Be(NotifyCollectionChangedAction.Add);
+
+        var silentSource = new ObservableCollection<int>();
+        _ = new ReactiveGroup<string, int>("numbers", silentSource);
+        Action addWithoutSubscriber = () => silentSource.Add(1);
+
+        addWithoutSubscriber.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// SecondaryIndex should reject keys of the wrong type in MatchesKey.
+    /// </summary>
+    [Test]
+    public void SecondaryIndex_MatchesKey_ShouldRejectWrongKeyType()
+    {
+        var index = new SecondaryIndex<Person, string>(person => person.Department);
+        var person = new Person(1, "Ada", "Engineering");
+
+        index.MatchesKey(person, "Engineering").Should().BeTrue();
+        index.MatchesKey(person, 123).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Internal grouping should expose its non-generic enumerator.
+    /// </summary>
+    [Test]
+    public void ChangeGrouping_ShouldExposeNonGenericEnumerator()
+    {
+        var grouping = new ChangeGrouping<string, int>("numbers", new[] { 1, 2 });
+
+        grouping.Key.Should().Be("numbers");
+        ((IEnumerable)grouping).Cast<int>().Should().Equal(1, 2);
+    }
+
+    private static PooledBatch<int> CreateBatch(params int[] values)
+    {
+        var array = ArrayPool<int>.Shared.Rent(Math.Max(1, values.Length));
+        Array.Copy(values, array, values.Length);
+        return new PooledBatch<int>(array, values.Length);
+    }
+
+    private static PooledBatch<string> CreateStringBatch(params string[] values)
+    {
+        var array = ArrayPool<string>.Shared.Rent(Math.Max(1, values.Length));
+        Array.Copy(values, array, values.Length);
+        return new PooledBatch<string>(array, values.Length);
+    }
+
+    private sealed record Person(int Id, string Name, string Department);
+}

--- a/src/ReactiveList.Test/DynamicSearchTests.cs
+++ b/src/ReactiveList.Test/DynamicSearchTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -11,7 +11,7 @@ using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using CP.Reactive.Collections;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -24,7 +24,7 @@ public class DynamicSearchTests
     /// Search should return matching items when query matches LastName.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task SearchByLastName_WhenQueryMatchesShouldReturnMatchingItemsAsync()
     {
         // Arrange
@@ -71,7 +71,7 @@ public class DynamicSearchTests
     /// Search should return matching items when query matches Email.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task SearchByEmail_WhenQueryMatchesShouldReturnMatchingItemsAsync()
     {
         // Arrange
@@ -116,7 +116,7 @@ public class DynamicSearchTests
     /// Empty search query should return all items.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task EmptyQuery_ShouldReturnAllItemsAsync()
     {
         // Arrange
@@ -158,7 +158,7 @@ public class DynamicSearchTests
     /// Search should be case insensitive.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task Search_ShouldBeCaseInsensitiveAsync()
     {
         // Arrange
@@ -205,7 +205,7 @@ public class DynamicSearchTests
     /// Search results should update when contacts are added after search.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task SearchResults_ShouldUpdateWhenContactsAddedAsync()
     {
         // Arrange
@@ -265,7 +265,7 @@ public class DynamicSearchTests
     /// Non-matching query should return empty results.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task NonMatchingQuery_ShouldReturnEmptyResultsAsync()
     {
         // Arrange

--- a/src/ReactiveList.Test/EditableListWrapperPoolTests.cs
+++ b/src/ReactiveList.Test/EditableListWrapperPoolTests.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -19,7 +19,7 @@ public class EditableListWrapperPoolTests
     /// <summary>
     /// Tests that Rent returns a new wrapper when pool is empty.
     /// </summary>
-    [Fact]
+    [Test]
     public void Rent_ReturnsNewWrapperWhenPoolEmpty()
     {
         // Arrange
@@ -37,7 +37,7 @@ public class EditableListWrapperPoolTests
     /// <summary>
     /// Tests that Return adds wrapper to pool.
     /// </summary>
-    [Fact]
+    [Test]
     public void Return_AddsWrapperToPool()
     {
         // Arrange
@@ -55,7 +55,7 @@ public class EditableListWrapperPoolTests
     /// <summary>
     /// Tests that Rent reuses wrapper from pool.
     /// </summary>
-    [Fact]
+    [Test]
     public void Rent_ReusesWrapperFromPool()
     {
         // Arrange
@@ -80,7 +80,7 @@ public class EditableListWrapperPoolTests
     /// <summary>
     /// Tests that wrapper operations work correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void PooledWrapper_OperationsWork()
     {
         // Arrange
@@ -110,7 +110,7 @@ public class EditableListWrapperPoolTests
     /// <summary>
     /// Tests that wrapper syncs with observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void PooledWrapper_SyncsWithObservableCollection()
     {
         // Arrange
@@ -130,7 +130,7 @@ public class EditableListWrapperPoolTests
     /// <summary>
     /// Tests that disposed wrapper throws when used.
     /// </summary>
-    [Fact]
+    [Test]
     public void PooledWrapper_ThrowsAfterDispose()
     {
         // Arrange
@@ -146,7 +146,7 @@ public class EditableListWrapperPoolTests
     /// <summary>
     /// Tests that MaxPoolSize limits pool growth.
     /// </summary>
-    [Fact]
+    [Test]
     public void MaxPoolSize_LimitsPoolGrowth()
     {
         // Arrange
@@ -181,7 +181,7 @@ public class EditableListWrapperPoolTests
     /// <summary>
     /// Tests that IResettable.Reset clears wrapper state.
     /// </summary>
-    [Fact]
+    [Test]
     public void IResettable_Reset_ClearsState()
     {
         // Arrange

--- a/src/ReactiveList.Test/EditableListWrapperTests.cs
+++ b/src/ReactiveList.Test/EditableListWrapperTests.cs
@@ -7,7 +7,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using CP.Reactive.Internal;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -19,7 +19,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Constructor should initialize with list only.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithListOnly_ShouldInitialize()
     {
         var list = new List<string> { "one", "two" };
@@ -33,7 +33,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Constructor should initialize with list and observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithListAndObservableCollection_ShouldInitialize()
     {
         var list = new List<string> { "one", "two" };
@@ -47,7 +47,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// IsReadOnly should return false.
     /// </summary>
-    [Fact]
+    [Test]
     public void IsReadOnly_ShouldReturnFalse()
     {
         var wrapper = new EditableListWrapper<string>([]);
@@ -57,7 +57,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Indexer get should return correct item.
     /// </summary>
-    [Fact]
+    [Test]
     public void Indexer_Get_ShouldReturnCorrectItem()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -69,7 +69,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Indexer set should update list only when no observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void Indexer_Set_WithoutObservable_ShouldUpdateList()
     {
         var list = new List<string> { "one", "two" };
@@ -83,7 +83,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Indexer set should update both list and observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void Indexer_Set_WithObservable_ShouldUpdateBoth()
     {
         var list = new List<string> { "one", "two" };
@@ -99,7 +99,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Add should add to list only when no observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void Add_WithoutObservable_ShouldAddToList()
     {
         var list = new List<string>();
@@ -113,7 +113,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Add should add to both list and observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void Add_WithObservable_ShouldAddToBoth()
     {
         var list = new List<string>();
@@ -129,7 +129,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// AddRange should add array items to list.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_WithArray_ShouldAddItems()
     {
         var list = new List<string>();
@@ -143,7 +143,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// AddRange should add items to both list and observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_WithObservable_ShouldAddToBoth()
     {
         var list = new List<string>();
@@ -159,7 +159,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// AddRange should handle enumerable that is not array.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_WithEnumerable_ShouldAddItems()
     {
         var list = new List<string>();
@@ -173,7 +173,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Clear should clear list only when no observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void Clear_WithoutObservable_ShouldClearList()
     {
         var list = new List<string> { "one", "two" };
@@ -187,7 +187,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Clear should clear both list and observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void Clear_WithObservable_ShouldClearBoth()
     {
         var list = new List<string> { "one", "two" };
@@ -203,7 +203,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Contains should return true for existing item.
     /// </summary>
-    [Fact]
+    [Test]
     public void Contains_WithExistingItem_ShouldReturnTrue()
     {
         var list = new List<string> { "one", "two" };
@@ -215,7 +215,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Contains should return false for non-existing item.
     /// </summary>
-    [Fact]
+    [Test]
     public void Contains_WithNonExistingItem_ShouldReturnFalse()
     {
         var list = new List<string> { "one", "two" };
@@ -227,7 +227,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// CopyTo should copy items to array.
     /// </summary>
-    [Fact]
+    [Test]
     public void CopyTo_ShouldCopyItemsToArray()
     {
         var list = new List<string> { "one", "two" };
@@ -244,7 +244,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// GetEnumerator should enumerate items.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetEnumerator_ShouldEnumerateItems()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -258,7 +258,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// IndexOf should return correct index.
     /// </summary>
-    [Fact]
+    [Test]
     public void IndexOf_ShouldReturnCorrectIndex()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -270,7 +270,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// IndexOf should return -1 for non-existing item.
     /// </summary>
-    [Fact]
+    [Test]
     public void IndexOf_WithNonExistingItem_ShouldReturnNegativeOne()
     {
         var list = new List<string> { "one", "two" };
@@ -282,7 +282,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Insert should insert at correct position without observable.
     /// </summary>
-    [Fact]
+    [Test]
     public void Insert_WithoutObservable_ShouldInsertAtPosition()
     {
         var list = new List<string> { "one", "three" };
@@ -296,7 +296,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Insert should insert at correct position with observable.
     /// </summary>
-    [Fact]
+    [Test]
     public void Insert_WithObservable_ShouldInsertInBoth()
     {
         var list = new List<string> { "one", "three" };
@@ -312,7 +312,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Move should move item to new position.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldMoveItemToNewPosition()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -326,7 +326,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Move should move item in both list and observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_WithObservable_ShouldMoveInBoth()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -342,7 +342,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Move should do nothing when old and new index are same.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_WhenSameIndex_ShouldDoNothing()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -356,7 +356,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Move should throw when old index is out of range.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_WhenOldIndexOutOfRange_ShouldThrow()
     {
         var list = new List<string> { "one", "two" };
@@ -371,7 +371,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Move should throw when new index is out of range.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_WhenNewIndexOutOfRange_ShouldThrow()
     {
         var list = new List<string> { "one", "two" };
@@ -386,7 +386,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Remove should remove existing item and return true.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ExistingItem_ShouldRemoveAndReturnTrue()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -401,7 +401,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Remove should return false for non-existing item.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_NonExistingItem_ShouldReturnFalse()
     {
         var list = new List<string> { "one", "two" };
@@ -416,7 +416,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Remove should remove from both list and observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_WithObservable_ShouldRemoveFromBoth()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -432,7 +432,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// RemoveAt should remove item at index without observable.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_WithoutObservable_ShouldRemoveAtIndex()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -446,7 +446,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// RemoveAt should remove from both list and observable collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_WithObservable_ShouldRemoveFromBoth()
     {
         var list = new List<string> { "one", "two", "three" };
@@ -462,7 +462,7 @@ public class EditableListWrapperTests
     /// <summary>
     /// Non-generic GetEnumerator should enumerate items.
     /// </summary>
-    [Fact]
+    [Test]
     public void NonGenericGetEnumerator_ShouldEnumerateItems()
     {
         var list = new List<string> { "one", "two" };

--- a/src/ReactiveList.Test/ExtensionCoverageTests.cs
+++ b/src/ReactiveList.Test/ExtensionCoverageTests.cs
@@ -1,0 +1,487 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using CP.Reactive;
+using CP.Reactive.Collections;
+using CP.Reactive.Core;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace ReactiveList.Tests;
+
+/// <summary>
+/// Coverage tests for extension pipelines.
+/// </summary>
+public class ExtensionCoverageTests
+{
+    /// <summary>
+    /// Change-set operators should handle empty, partial, all-match, and projection paths.
+    /// </summary>
+    [Test]
+    public void ChangeSetOperators_ShouldHandleEmptyNoMatchPartialAllAndPreviousValues()
+    {
+        var source = new Subject<ChangeSet<int>>();
+        var filtered = new List<ChangeSet<int>>();
+
+        using var filterSubscription = source
+            .WhereChanges(static change => change.Current % 2 == 0)
+            .Subscribe(filtered.Add);
+
+        source.OnNext(ChangeSet<int>.Empty);
+        source.OnNext(new ChangeSet<int>(new[] { Change<int>.CreateAdd(1), Change<int>.CreateAdd(3) }));
+        source.OnNext(new ChangeSet<int>(new[] { Change<int>.CreateAdd(1), Change<int>.CreateAdd(2), Change<int>.CreateAdd(4) }));
+        var allMatch = new ChangeSet<int>(new[] { Change<int>.CreateAdd(6), Change<int>.CreateAdd(8) });
+        source.OnNext(allMatch);
+
+        filtered.Should().HaveCount(2);
+        filtered[0].Select(static change => change.Current).Should().Equal(2, 4);
+        filtered[1].Equals(allMatch).Should().BeTrue();
+
+        Func<string, string> itemSelector = static item => $"value-{item}";
+        var projectedSets = new List<ChangeSet<string>>();
+        using var projectionSubscription = Observable.Return(new ChangeSet<string>(new[]
+            {
+                Change<string>.CreateUpdate("twenty", "ten", 0),
+                Change<string>.CreateAdd("thirty", 1),
+            }))
+            .SelectChanges(itemSelector)
+            .Subscribe(projectedSets.Add);
+
+        projectedSets.Should().ContainSingle();
+        projectedSets[0][0].Previous.Should().Be("value-ten");
+        projectedSets[0][0].Current.Should().Be("value-twenty");
+        projectedSets[0][1].Previous.Should().BeNull();
+
+        Func<Change<int>, string> changeSelector = static change => $"{change.Reason}:{change.Current}";
+        var flattened = new List<string>();
+        using var flattenSubscription = Observable.Return(new ChangeSet<int>(new[]
+            {
+                Change<int>.CreateRemove(5),
+                Change<int>.CreateMove(6, 2, 0),
+            }))
+            .SelectChanges(changeSelector)
+            .Subscribe(flattened.Add);
+
+        flattened.Should().Equal("Remove:5", "Move:6");
+
+        var emptyFlattened = new List<int>();
+        using var emptySubscription = Observable.Return(ChangeSet<int>.Empty)
+            .SelectChanges(static change => change.Current)
+            .Subscribe(emptyFlattened.Add);
+
+        emptyFlattened.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Change-set operators should reject null arguments.
+    /// </summary>
+    [Test]
+    public void ChangeSetOperators_WithNullArguments_ShouldThrow()
+    {
+        IObservable<ChangeSet<int>> nullSource = null!;
+
+        var whereSource = () => nullSource.WhereChanges(static _ => true);
+        var wherePredicate = () => ReactiveListExtensions.WhereChanges<int>(Observable.Empty<ChangeSet<int>>(), null!);
+        var selectSource = () => ReactiveListExtensions.SelectChanges<int, string>(nullSource, (Func<int, string>)(static item => item.ToString()));
+        var selectItemSelector = () => ReactiveListExtensions.SelectChanges<int, string>(Observable.Empty<ChangeSet<int>>(), (Func<int, string>)null!);
+        var selectChangeSelector = () => ReactiveListExtensions.SelectChanges<int, string>(Observable.Empty<ChangeSet<int>>(), (Func<Change<int>, string>)null!);
+
+        whereSource.Should().Throw<ArgumentNullException>().WithParameterName("source");
+        wherePredicate.Should().Throw<ArgumentNullException>().WithParameterName("predicate");
+        selectSource.Should().Throw<ArgumentNullException>().WithParameterName("source");
+        selectItemSelector.Should().Throw<ArgumentNullException>().WithParameterName("selector");
+        selectChangeSelector.Should().Throw<ArgumentNullException>().WithParameterName("selector");
+    }
+
+    /// <summary>
+    /// Generic dynamic stream filters should handle single, batch, remove, and clear notifications.
+    /// </summary>
+    [Test]
+    public void FilterDynamic_GenericStream_ShouldFilterAddsBatchesAndPassRemovesAndClears()
+    {
+        using var stream = new Subject<CacheNotify<int>>();
+        using var filters = new BehaviorSubject<Func<int, bool>>(static item => item % 2 == 0);
+        var received = new List<CacheNotify<int>>();
+
+        using var subscription = stream
+            .FilterDynamic(filters)
+            .Subscribe(received.Add);
+
+        stream.OnNext(new CacheNotify<int>(CacheAction.Added, 2));
+        stream.OnNext(new CacheNotify<int>(CacheAction.Added, 3));
+        stream.OnNext(new CacheNotify<int>(CacheAction.Removed, 3));
+        stream.OnNext(new CacheNotify<int>(CacheAction.BatchOperation, default, CreateBatch(4, 5, 6)));
+        stream.OnNext(new CacheNotify<int>(CacheAction.BatchOperation, default, CreateBatch(5, 7)));
+        stream.OnNext(new CacheNotify<int>(CacheAction.Cleared, default));
+
+        received.Select(static notification => notification.Action)
+            .Should().Equal(CacheAction.Added, CacheAction.Removed, CacheAction.BatchOperation, CacheAction.Cleared);
+        received[0].Item.Should().Be(2);
+        received[1].Item.Should().Be(3);
+        received[2].Batch.Should().NotBeNull();
+        var genericBatch = received[2].Batch!;
+        genericBatch.Items.Take(genericBatch.Count).Should().Equal(4, 6);
+        received[3].Action.Should().Be(CacheAction.Cleared);
+
+        DisposeBatches(received);
+    }
+
+    /// <summary>
+    /// Dictionary dynamic stream filters should handle single, batch, remove, and clear notifications.
+    /// </summary>
+    [Test]
+    public void FilterDynamic_DictionaryStream_ShouldFilterAddsBatchesAndPassRemoves()
+    {
+        using var stream = new Subject<CacheNotify<KeyValuePair<int, string>>>();
+        using var filters = new BehaviorSubject<Func<KeyValuePair<int, string>, bool>>(static item => item.Value.StartsWith("a", StringComparison.Ordinal));
+        var received = new List<CacheNotify<KeyValuePair<int, string>>>();
+
+        using var subscription = stream
+            .FilterDynamic(filters)
+            .Subscribe(received.Add);
+
+        stream.OnNext(new CacheNotify<KeyValuePair<int, string>>(CacheAction.Added, new KeyValuePair<int, string>(1, "alpha")));
+        stream.OnNext(new CacheNotify<KeyValuePair<int, string>>(CacheAction.Added, new KeyValuePair<int, string>(2, "beta")));
+        stream.OnNext(new CacheNotify<KeyValuePair<int, string>>(CacheAction.Removed, new KeyValuePair<int, string>(2, "beta")));
+        stream.OnNext(new CacheNotify<KeyValuePair<int, string>>(CacheAction.BatchAdded, default, CreateBatch(
+            new KeyValuePair<int, string>(3, "atlas"),
+            new KeyValuePair<int, string>(4, "beta"))));
+        stream.OnNext(new CacheNotify<KeyValuePair<int, string>>(CacheAction.BatchRemoved, default, CreateBatch(
+            new KeyValuePair<int, string>(5, "apex"),
+            new KeyValuePair<int, string>(6, "cedar"))));
+        stream.OnNext(new CacheNotify<KeyValuePair<int, string>>(CacheAction.Cleared, default));
+
+        received.Select(static notification => notification.Action)
+            .Should().Equal(CacheAction.Added, CacheAction.Removed, CacheAction.BatchOperation, CacheAction.BatchOperation, CacheAction.Cleared);
+        received[0].Item.Value.Should().Be("alpha");
+        received[1].Item.Value.Should().Be("beta");
+        var addedBatch = received[2].Batch!;
+        var removedBatch = received[3].Batch!;
+        addedBatch.Items.Take(addedBatch.Count).Should().ContainSingle().Which.Value.Should().Be("atlas");
+        removedBatch.Items.Take(removedBatch.Count).Should().ContainSingle().Which.Value.Should().Be("apex");
+
+        DisposeBatches(received);
+    }
+
+    /// <summary>
+    /// Internal batch filter helpers should handle null, empty, and matching results.
+    /// </summary>
+    [Test]
+    public void BatchFilterHelpers_ShouldReturnNullForNoBatchOrNoMatchesAndFilterMatches()
+    {
+        var noBatch = new CacheNotify<int>(CacheAction.BatchOperation, default);
+        ReactiveListExtensions.FilterBatchByPredicate(noBatch, static _ => true).Should().BeNull();
+        ReactiveListExtensions.FilterBatch(noBatch, new HashSet<int> { 1 }).Should().BeNull();
+
+        var noMatch = new CacheNotify<int>(CacheAction.BatchOperation, default, CreateBatch(1, 3, 5));
+        ReactiveListExtensions.FilterBatchByPredicate(noMatch, static item => item % 2 == 0).Should().BeNull();
+        noMatch.Batch!.Dispose();
+
+        var predicateMatch = new CacheNotify<int>(CacheAction.BatchOperation, default, CreateBatch(1, 2, 4));
+        var predicateResult = ReactiveListExtensions.FilterBatchByPredicate(predicateMatch, static item => item > 1);
+        predicateResult.Should().NotBeNull();
+        predicateResult!.Batch!.Items.Take(predicateResult.Batch.Count).Should().Equal(2, 4);
+        predicateMatch.Batch!.Dispose();
+        predicateResult.Batch.Dispose();
+
+        var setMatch = new CacheNotify<int>(CacheAction.BatchOperation, default, CreateBatch(1, 2, 3));
+        var setResult = ReactiveListExtensions.FilterBatch(setMatch, new HashSet<int> { 1, 3 });
+        setResult.Should().NotBeNull();
+        setResult!.Batch!.Items.Take(setResult.Batch.Count).Should().Equal(1, 3);
+        setMatch.Batch!.Dispose();
+        setResult.Batch.Dispose();
+    }
+
+    /// <summary>
+    /// Grouping and auto-refresh operators should emit grouped changes and property refreshes.
+    /// </summary>
+    [Test]
+    public void GroupingAndAutoRefresh_ShouldGroupChangesAndEmitPropertyRefreshes()
+    {
+        var north = new MutableItem(1, "north", "alpha");
+        var south = new MutableItem(2, "south", "beta");
+        var changes = new ChangeSet<MutableItem>(new[]
+        {
+            Change<MutableItem>.CreateAdd(north),
+            Change<MutableItem>.CreateAdd(south),
+            Change<MutableItem>.CreateUpdate(north, north),
+        });
+
+        var groupings = new List<IGrouping<string, Change<MutableItem>>>();
+        using var groupingSubscription = Observable.Return(changes)
+            .GroupingByChanges(static item => item.Region)
+            .Subscribe(groupings.Add);
+
+        groupings.Should().HaveCount(2);
+        groupings.Single(static group => group.Key == "north").Should().HaveCount(2);
+        groupings.Single(static group => group.Key == "south").Should().ContainSingle();
+
+        var groupedValues = new Dictionary<string, List<MutableItem>>();
+        using var groupBySubscription = Observable.Return(changes)
+            .GroupByChanges(static item => item.Region)
+            .Subscribe(group =>
+            {
+                groupedValues[group.Key] = new List<MutableItem>();
+                group.Subscribe(item => groupedValues[group.Key].Add(item));
+            });
+
+        groupedValues["north"].Should().HaveCount(2);
+        groupedValues["south"].Should().ContainSingle().Which.Should().Be(south);
+
+        using var refreshSource = new Subject<ChangeSet<MutableItem>>();
+        var received = new List<ChangeSet<MutableItem>>();
+        using var refreshSubscription = refreshSource
+            .AutoRefresh(nameof(MutableItem.Name))
+            .Subscribe(received.Add);
+
+        refreshSource.OnNext(new ChangeSet<MutableItem>(Change<MutableItem>.CreateAdd(north, 0)));
+        north.RaisePropertyChanged(nameof(MutableItem.Region));
+        north.RaisePropertyChanged(nameof(MutableItem.Name));
+
+        received.Should().HaveCount(2);
+        received[0][0].Reason.Should().Be(ChangeReason.Add);
+        received[1][0].Reason.Should().Be(ChangeReason.Refresh);
+        received[1][0].Current.Should().Be(north);
+        received[1][0].CurrentIndex.Should().Be(0);
+
+        var allProperties = new List<ChangeSet<MutableItem>>();
+        using var allSubscription = refreshSource
+            .AutoRefresh(null)
+            .Subscribe(allProperties.Add);
+
+        refreshSource.OnNext(new ChangeSet<MutableItem>(Change<MutableItem>.CreateUpdate(south, south, 1)));
+        south.RaisePropertyChanged(nameof(MutableItem.Region));
+
+        allProperties.Should().HaveCount(2);
+        allProperties[1][0].Reason.Should().Be(ChangeReason.Refresh);
+    }
+
+    /// <summary>
+    /// Source auto-refresh expression overload should validate property expressions and return the source stream.
+    /// </summary>
+    [Test]
+    public void AutoRefresh_SourceExpression_ShouldValidatePropertyAndReturnSourceStream()
+    {
+        using var list = new ReactiveList<MutableItem>();
+        var received = new List<CacheNotify<MutableItem>>();
+
+        using var subscription = list
+            .AutoRefresh(static item => item.Name)
+            .Subscribe(received.Add);
+
+        var item = new MutableItem(1, "north", "alpha");
+        list.Add(item);
+
+        received.Should().ContainSingle();
+        received[0].Action.Should().Be(CacheAction.Added);
+
+        var invalidExpression = () => list.AutoRefresh(static _ => new object());
+        invalidExpression.Should().Throw<ArgumentException>().WithParameterName("property");
+    }
+
+    /// <summary>
+    /// View factory extensions should create filtered, sorted, grouped, and dynamic views.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task ViewFactoryExtensions_ShouldCreateViewsWithFallbackSchedulersAndDynamicFilters()
+    {
+        using var list = new ReactiveList<int>();
+        list.AddRange(new[] { 3, 1, 2 });
+
+        using var filtered = list.CreateView(static item => item > 1, scheduler: null, throttleMs: 0);
+        filtered.Items.Should().BeEquivalentTo(new[] { 2, 3 });
+
+        using var dynamicFilters = new BehaviorSubject<Func<int, bool>>(static item => item == 1);
+        using var dynamicFiltered = list.CreateView(dynamicFilters, scheduler: null, throttleMs: 0);
+        await WaitForPipeline();
+        dynamicFiltered.Items.Should().Equal(1);
+
+        using var sorted = list.SortBy(static item => item, descending: true, scheduler: null, throttleMs: 0);
+        sorted.Items.Should().Equal(3, 2, 1);
+
+        using var grouped = list.GroupBy(static item => item % 2, scheduler: null, throttleMs: 0);
+        grouped.Keys.Should().BeEquivalentTo(new[] { 0, 1 });
+
+#if NET8_0_OR_GREATER || NETFRAMEWORK
+        using var quaternary = new QuaternaryList<string>();
+        quaternary.Add("apple");
+        quaternary.Add("banana");
+
+        using var query = new BehaviorSubject<string>("app");
+        using var queryView = quaternary.CreateView(
+            query,
+            static (queryText, item) => item.StartsWith(queryText, StringComparison.Ordinal),
+            ImmediateScheduler.Instance,
+            throttleMs: 0);
+        queryView.Items.Should().Equal("apple");
+
+        using var sourceFilters = new BehaviorSubject<Func<string, bool>>(static item => item.Contains("a", StringComparison.Ordinal));
+        using var sourceView = quaternary.CreateView(sourceFilters, ImmediateScheduler.Instance, throttleMs: 0);
+        sourceView.Items.Should().BeEquivalentTo(new[] { "apple", "banana" });
+#endif
+    }
+
+#if NET8_0_OR_GREATER || NETFRAMEWORK
+    /// <summary>
+    /// Quaternary list secondary-index filters should pass matching single and batch notifications.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task QuaternaryListSecondaryIndexFilter_ShouldPassMatchingSingleAndBatchNotifications()
+    {
+        using var list = new QuaternaryList<IndexedItem>();
+        list.AddIndex("region", static item => item.Region);
+        var singleKey = new List<CacheNotify<IndexedItem>>();
+        var multipleKeys = new List<CacheNotify<IndexedItem>>();
+
+        using var singleSubscription = list.Stream
+            .FilterBySecondaryIndex(list, "region", "north")
+            .Subscribe(singleKey.Add);
+        using var multipleSubscription = list.Stream
+            .FilterBySecondaryIndex(list, "region", "north", "east")
+            .Subscribe(multipleKeys.Add);
+
+        var north = new IndexedItem(1, "north");
+        var east = new IndexedItem(2, "east");
+        var south = new IndexedItem(3, "south");
+
+        list.Add(north);
+        list.Add(east);
+        list.Add(south);
+        list.Remove(north);
+
+        var northBatch = new IndexedItem(4, "north");
+        var eastBatch = new IndexedItem(5, "east");
+        var southBatch = new IndexedItem(6, "south");
+        list.AddRange(new[] { northBatch, eastBatch, southBatch });
+        list.RemoveRange(new[] { northBatch, eastBatch, southBatch });
+
+        await WaitForPipeline();
+
+        singleKey.Select(static notification => notification.Action)
+            .Should().Equal(CacheAction.Added, CacheAction.Removed, CacheAction.BatchOperation, CacheAction.BatchOperation);
+        singleKey[0].Item.Should().Be(north);
+        singleKey[1].Item.Should().Be(north);
+        var singleAddedBatch = singleKey[2].Batch!;
+        var singleRemovedBatch = singleKey[3].Batch!;
+        singleAddedBatch.Items.Take(singleAddedBatch.Count).Should().ContainSingle().Which.Should().Be(northBatch);
+        singleRemovedBatch.Items.Take(singleRemovedBatch.Count).Should().ContainSingle().Which.Should().Be(northBatch);
+
+        multipleKeys.Select(static notification => notification.Action)
+            .Should().Equal(
+                CacheAction.Added,
+                CacheAction.Added,
+                CacheAction.Removed,
+                CacheAction.BatchOperation,
+                CacheAction.BatchOperation);
+        var multipleAddedBatch = multipleKeys[3].Batch!;
+        var multipleRemovedBatch = multipleKeys[4].Batch!;
+        multipleAddedBatch.Items.Take(multipleAddedBatch.Count).Should().BeEquivalentTo(new[] { northBatch, eastBatch });
+        multipleRemovedBatch.Items.Take(multipleRemovedBatch.Count).Should().BeEquivalentTo(new[] { northBatch, eastBatch });
+
+        DisposeBatches(singleKey);
+        DisposeBatches(multipleKeys);
+    }
+
+    /// <summary>
+    /// Quaternary dictionary secondary-index filters should pass matching single and batch notifications.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task QuaternaryDictionarySecondaryIndexFilter_ShouldPassMatchingSingleAndBatchNotifications()
+    {
+        using var dictionary = new QuaternaryDictionary<int, IndexedItem>();
+        dictionary.AddValueIndex("region", static item => item.Region);
+        var singleKey = new List<CacheNotify<KeyValuePair<int, IndexedItem>>>();
+        var multipleKeys = new List<CacheNotify<KeyValuePair<int, IndexedItem>>>();
+
+        using var singleSubscription = dictionary.Stream
+            .FilterBySecondaryIndex(dictionary, "region", "north")
+            .Subscribe(singleKey.Add);
+        using var multipleSubscription = dictionary.Stream
+            .FilterBySecondaryIndex(dictionary, "region", "north", "east")
+            .Subscribe(multipleKeys.Add);
+
+        var north = new IndexedItem(1, "north");
+        var east = new IndexedItem(2, "east");
+        var south = new IndexedItem(3, "south");
+
+        dictionary.Add(1, north);
+        dictionary.Add(2, east);
+        dictionary.Add(3, south);
+        dictionary.Remove(1);
+
+        var northBatch = new KeyValuePair<int, IndexedItem>(4, new IndexedItem(4, "north"));
+        var eastBatch = new KeyValuePair<int, IndexedItem>(5, new IndexedItem(5, "east"));
+        var southBatch = new KeyValuePair<int, IndexedItem>(6, new IndexedItem(6, "south"));
+        dictionary.AddRange(new[] { northBatch, eastBatch, southBatch });
+
+        await WaitForPipeline();
+
+        singleKey.Select(static notification => notification.Action)
+            .Should().Equal(CacheAction.Added, CacheAction.Removed, CacheAction.BatchOperation);
+        singleKey[0].Item.Value.Should().Be(north);
+        singleKey[1].Item.Value.Should().Be(north);
+        var dictionarySingleBatch = singleKey[2].Batch!;
+        dictionarySingleBatch.Items.Take(dictionarySingleBatch.Count).Should().ContainSingle().Which.Should().Be(northBatch);
+
+        multipleKeys.Select(static notification => notification.Action)
+            .Should().Equal(CacheAction.Added, CacheAction.Added, CacheAction.Removed, CacheAction.BatchOperation);
+        var dictionaryMultipleBatch = multipleKeys[3].Batch!;
+        dictionaryMultipleBatch.Items.Take(dictionaryMultipleBatch.Count).Should().BeEquivalentTo(new[] { northBatch, eastBatch });
+
+        DisposeBatches(singleKey);
+        DisposeBatches(multipleKeys);
+    }
+#endif
+
+    private static async Task WaitForPipeline() => await Task.Delay(30);
+
+    private static PooledBatch<T> CreateBatch<T>(params T[] items)
+    {
+        var array = ArrayPool<T>.Shared.Rent(items.Length);
+        Array.Copy(items, array, items.Length);
+        return new PooledBatch<T>(array, items.Length);
+    }
+
+    private static void DisposeBatches<T>(IEnumerable<CacheNotify<T>> notifications)
+    {
+        foreach (var batch in notifications.Select(static notification => notification.Batch).Where(static batch => batch != null))
+        {
+            batch!.Dispose();
+        }
+    }
+
+    private sealed record IndexedItem(int Id, string Region);
+
+    private sealed class MutableItem : INotifyPropertyChanged
+    {
+        public MutableItem(int id, string region, string name)
+        {
+            Id = id;
+            Region = region;
+            Name = name;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public int Id { get; }
+
+        public string Name { get; }
+
+        public string Region { get; }
+
+        public void RaisePropertyChanged(string? propertyName) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/ReactiveList.Test/ModuleInitializerAttribute.cs
+++ b/src/ReactiveList.Test/ModuleInitializerAttribute.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Indicates that a method is a module initializer.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class ModuleInitializerAttribute : Attribute
+{
+}
+#endif

--- a/src/ReactiveList.Test/PooledBatchTests.cs
+++ b/src/ReactiveList.Test/PooledBatchTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Buffers;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -17,7 +17,7 @@ public class PooledBatchTests
     /// <summary>
     /// Constructor should initialize Items and Count.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_ShouldInitializeProperties()
     {
         var array = ArrayPool<int>.Shared.Rent(10);
@@ -34,7 +34,7 @@ public class PooledBatchTests
     /// <summary>
     /// Items should be accessible before dispose.
     /// </summary>
-    [Fact]
+    [Test]
     public void Items_BeforeDispose_ShouldBeAccessible()
     {
         var array = ArrayPool<string>.Shared.Rent(5);
@@ -50,7 +50,7 @@ public class PooledBatchTests
     /// <summary>
     /// Count should reflect actual item count.
     /// </summary>
-    [Fact]
+    [Test]
     public void Count_ShouldReflectActualItemCount()
     {
         var array = ArrayPool<double>.Shared.Rent(100);
@@ -63,7 +63,7 @@ public class PooledBatchTests
     /// <summary>
     /// Dispose should return array to pool.
     /// </summary>
-    [Fact]
+    [Test]
     public void Dispose_ShouldReturnArrayToPool()
     {
         var array = ArrayPool<int>.Shared.Rent(10);
@@ -77,7 +77,7 @@ public class PooledBatchTests
     /// <summary>
     /// Multiple dispose calls should be safe.
     /// </summary>
-    [Fact]
+    [Test]
     public void Dispose_MultipleCalls_ShouldBeSafe()
     {
         var array = ArrayPool<int>.Shared.Rent(10);
@@ -92,7 +92,7 @@ public class PooledBatchTests
     /// <summary>
     /// Record equality should work correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void RecordEquality_ShouldWorkCorrectly()
     {
         var array = ArrayPool<int>.Shared.Rent(10);
@@ -109,7 +109,7 @@ public class PooledBatchTests
     /// <summary>
     /// Record inequality should work for different counts.
     /// </summary>
-    [Fact]
+    [Test]
     public void RecordInequality_DifferentCounts_ShouldNotBeEqual()
     {
         var array = ArrayPool<int>.Shared.Rent(10);
@@ -126,7 +126,7 @@ public class PooledBatchTests
     /// <summary>
     /// PooledBatch should work with reference types.
     /// </summary>
-    [Fact]
+    [Test]
     public void PooledBatch_WithReferenceTypes_ShouldWork()
     {
         var array = ArrayPool<string>.Shared.Rent(5);
@@ -143,7 +143,7 @@ public class PooledBatchTests
     /// <summary>
     /// PooledBatch with zero count should be valid.
     /// </summary>
-    [Fact]
+    [Test]
     public void PooledBatch_WithZeroCount_ShouldBeValid()
     {
         var array = ArrayPool<int>.Shared.Rent(10);
@@ -157,7 +157,7 @@ public class PooledBatchTests
     /// <summary>
     /// PooledBatch should support with expression.
     /// </summary>
-    [Fact]
+    [Test]
     public void PooledBatch_WithExpression_ShouldWork()
     {
         var array = ArrayPool<int>.Shared.Rent(10);
@@ -175,7 +175,7 @@ public class PooledBatchTests
     /// <summary>
     /// GetHashCode should be consistent.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetHashCode_ShouldBeConsistent()
     {
         var array = ArrayPool<int>.Shared.Rent(10);
@@ -192,7 +192,7 @@ public class PooledBatchTests
     /// <summary>
     /// ToString should return meaningful representation.
     /// </summary>
-    [Fact]
+    [Test]
     public void ToString_ShouldReturnMeaningfulRepresentation()
     {
         var array = ArrayPool<int>.Shared.Rent(10);

--- a/src/ReactiveList.Test/QuadCollectionCoverageTests.cs
+++ b/src/ReactiveList.Test/QuadCollectionCoverageTests.cs
@@ -1,0 +1,306 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET8_0_OR_GREATER || NETFRAMEWORK
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using CP.Reactive.Collections;
+using CP.Reactive.Internal;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace ReactiveList.Test;
+
+/// <summary>
+/// Covers low-level quad collection and pooled helper paths that are not reached by the public collection tests.
+/// </summary>
+public class QuadCollectionCoverageTests
+{
+    /// <summary>
+    /// Verifies QuadList indexing, resizing, removal, copy, and enumerator wrapper behavior.
+    /// </summary>
+    [Test]
+    public void QuadList_ShouldSupportMutationAndEnumerationPaths()
+    {
+        using var list = new QuadList<int>();
+
+        list.AddRange(ReadOnlySpan<int>.Empty);
+        Enumerable.Range(0, 40).ToList().ForEach(list.Add);
+
+        list.Count.Should().Be(40);
+        list[3].Should().Be(3);
+
+        list[3] = 300;
+        list[3].Should().Be(300);
+        list.Contains(300).Should().BeTrue();
+        list.IndexOf(300).Should().Be(3);
+
+        list.Remove(300).Should().BeTrue();
+        list.Remove(999).Should().BeFalse();
+        list.RemoveAt(list.Count - 1);
+
+        var copied = new int[list.Count + 2];
+        list.CopyTo(copied, 1);
+        copied[1].Should().Be(0);
+
+        var structEnumerator = list.GetEnumerator();
+        structEnumerator.MoveNext().Should().BeTrue();
+        structEnumerator.Current.Should().Be(0);
+        while (structEnumerator.MoveNext())
+        {
+        }
+
+        structEnumerator.MoveNext().Should().BeFalse();
+
+        using var enumerator = ((IEnumerable<int>)list).GetEnumerator();
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Should().Be(0);
+        enumerator.Reset();
+        enumerator.MoveNext().Should().BeTrue();
+        ((IEnumerator)enumerator).Current.Should().Be(0);
+
+        var nonGenericEnumerator = ((IEnumerable)list).GetEnumerator();
+        nonGenericEnumerator.MoveNext().Should().BeTrue();
+        nonGenericEnumerator.Current.Should().Be(0);
+
+        list.AsSpan().ToArray().Should().Contain(38);
+        list.AsSpan().ToArray().Should().NotContain(39);
+        list.Clear();
+        list.Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Verifies QuadList guard clauses for invalid indexes.
+    /// </summary>
+    [Test]
+    public void QuadList_InvalidIndexes_ShouldThrow()
+    {
+        using var list = new QuadList<string>();
+        list.Add("first");
+
+        Action getNegative = () => _ = list[-1];
+        Action getTooHigh = () => _ = list[1];
+        Action setTooHigh = () => list[1] = "missing";
+        Action removeTooHigh = () => list.RemoveAt(1);
+
+        getNegative.Should().Throw<IndexOutOfRangeException>();
+        getTooHigh.Should().Throw<IndexOutOfRangeException>();
+        setTooHigh.Should().Throw<IndexOutOfRangeException>();
+        removeTooHigh.Should().Throw<IndexOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// Verifies QuadDictionary collision handling, ref updates, free-list reuse, and wrapper enumeration.
+    /// </summary>
+    [Test]
+    public void QuadDictionary_ShouldHandleCollisionsAndRemovedSlots()
+    {
+        using var dictionary = new QuadDictionary<string, int>(new ConstantHashStringComparer());
+
+        dictionary.TryAdd("one", 1).Should().BeTrue();
+        dictionary.TryAdd("two", 2).Should().BeTrue();
+        dictionary.TryAdd("three", 3).Should().BeTrue();
+        dictionary.TryAdd("two", 22).Should().BeFalse();
+        dictionary.Count.Should().Be(3);
+
+        dictionary.Remove("two", out var removedMiddle).Should().BeTrue();
+        removedMiddle.Should().Be(2);
+        dictionary.Remove("three").Should().BeTrue();
+        dictionary.Remove("missing", out var missingValue).Should().BeFalse();
+        missingValue.Should().Be(default(int));
+
+        dictionary.TryAdd("four", 4).Should().BeTrue();
+        dictionary["one"].Should().Be(1);
+        dictionary["one"] = 10;
+        dictionary["one"].Should().Be(10);
+
+        ref var valueRef = ref dictionary.GetValueRefOrAddDefault("five", out var existed);
+        existed.Should().BeFalse();
+        valueRef = 5;
+
+        ref var existingRef = ref dictionary.GetValueRefOrAddDefault("five", out existed);
+        existed.Should().BeTrue();
+        existingRef.Should().Be(5);
+
+        dictionary.GetKeys().Should().BeEquivalentTo(new[] { "one", "four", "five" });
+        dictionary.GetValues().Should().BeEquivalentTo(new[] { 10, 4, 5 });
+
+        var copied = new List<KeyValuePair<string, int>>();
+        dictionary.CopyTo(copied);
+        copied.Should().BeEquivalentTo(dictionary.ToArray());
+
+        var structEnumerator = dictionary.GetEnumerator();
+        structEnumerator.TryGetNext(out var first).Should().BeTrue();
+        first.Key.Should().NotBeNull();
+        while (structEnumerator.MoveNext())
+        {
+        }
+
+        structEnumerator.TryGetNext(out var afterLast).Should().BeFalse();
+        afterLast.Should().Be(default(KeyValuePair<string, int>));
+
+        using var wrapper = ((IEnumerable<KeyValuePair<string, int>>)dictionary).GetEnumerator();
+        wrapper.MoveNext().Should().BeTrue();
+        ((IEnumerator)wrapper).Current.Should().BeOfType<KeyValuePair<string, int>>();
+        wrapper.Reset();
+        wrapper.MoveNext().Should().BeTrue();
+
+        var nonGenericWrapper = ((IEnumerable)dictionary).GetEnumerator();
+        nonGenericWrapper.MoveNext().Should().BeTrue();
+        nonGenericWrapper.Current.Should().BeOfType<KeyValuePair<string, int>>();
+    }
+
+    /// <summary>
+    /// Verifies QuadDictionary duplicate, missing-key, capacity, resize, and clear behavior.
+    /// </summary>
+    [Test]
+    public void QuadDictionary_ShouldCoverGuardsCapacityAndClear()
+    {
+        using var dictionary = new QuadDictionary<int, string>();
+
+        dictionary.EnsureCapacity(8);
+        dictionary.EnsureCapacity(128);
+
+        Enumerable.Range(0, 120).ToList().ForEach(i => dictionary.Add(i, $"value-{i}"));
+
+        dictionary.Count.Should().Be(120);
+        dictionary.ContainsKey(42).Should().BeTrue();
+        dictionary.TryGetValue(999, out var missing).Should().BeFalse();
+        missing.Should().BeNull();
+
+        Action duplicateAdd = () => dictionary.Add(42, "duplicate");
+        Action missingIndexer = () => _ = dictionary[999];
+        Action nullCopyTarget = () => dictionary.CopyTo(null!);
+
+        duplicateAdd.Should().Throw<ArgumentException>();
+        missingIndexer.Should().Throw<KeyNotFoundException>();
+        nullCopyTarget.Should().Throw<ArgumentNullException>();
+
+        dictionary.Clear();
+        dictionary.Count.Should().Be(0);
+        dictionary.Clear();
+    }
+
+    /// <summary>
+    /// Verifies pooled batch change tracking including growth and reset on disposal.
+    /// </summary>
+    [Test]
+    public void BatchChangeTracker_ShouldTrackGrowAndDispose()
+    {
+        var tracker = default(BatchChangeTracker<string>);
+
+        for (var i = 0; i < 24; i++)
+        {
+            tracker.TrackAdded($"added-{i}");
+        }
+
+        for (var i = 0; i < 20; i++)
+        {
+            tracker.TrackRemoved($"removed-{i}");
+        }
+
+        tracker.HasChanges.Should().BeTrue();
+        tracker.AddedItems.ToArray().Should().StartWith("added-0").And.EndWith("added-23");
+        tracker.RemovedItems.ToArray().Should().StartWith("removed-0").And.EndWith("removed-19");
+
+        tracker.Dispose();
+
+        tracker.HasChanges.Should().BeFalse();
+        tracker.AddedItems.Length.Should().Be(0);
+        tracker.RemovedItems.Length.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Verifies ChangeToken value storage and change detection.
+    /// </summary>
+    [Test]
+    public void ChangeToken_ShouldReportVersionChanges()
+    {
+        var token = new ChangeToken<int>(version: 7, count: 3);
+
+        token.Version.Should().Be(7);
+        token.Count.Should().Be(3);
+        token.HasChanged(7).Should().BeFalse();
+        token.HasChanged(8).Should().BeTrue();
+        token.Should().Be(new ChangeToken<int>(7, 3));
+    }
+
+    /// <summary>
+    /// Verifies PooledBuffer list copying and idempotent disposal.
+    /// </summary>
+    [Test]
+    public void PooledBuffer_FromList_ShouldExposeCopiedSpanAndDispose()
+    {
+        var source = new List<string> { "alpha", "beta", "gamma" };
+        using var buffer = PooledBuffer<string>.FromList(source);
+
+        buffer.Span.ToArray().Should().Equal(source);
+
+        buffer.Dispose();
+        buffer.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies ValueBuffer stack, rent, growth, and disposal paths.
+    /// </summary>
+    [Test]
+    public void ValueBuffer_ShouldUseStackThenRentedStorage()
+    {
+        Span<int> stack = stackalloc int[2];
+        var buffer = new ValueBuffer<int>(in stack);
+
+        buffer.Add(1);
+        buffer.Add(2);
+        buffer.Span.ToArray().Should().Equal(1, 2);
+
+        buffer.Add(3);
+        for (var i = 4; i <= 40; i++)
+        {
+            buffer.Add(i);
+        }
+
+        buffer.Count.Should().Be(40);
+        buffer.Span.ToArray().Should().Equal(Enumerable.Range(1, 40));
+
+        buffer.Dispose();
+        buffer.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies shard hashing produces stable in-range shard indexes for null, positive, and negative hash codes.
+    /// </summary>
+    [Test]
+    public void ShardHash_ShouldReturnExpectedShardRanges()
+    {
+        ShardHash.GetShardIndex<string?>(null, 4).Should().Be(0);
+        ShardHash.GetShardIndex4<string?>(null).Should().Be(0);
+
+        var positive = new FixedHash(1);
+        var negative = new FixedHash(int.MinValue);
+
+        ShardHash.GetShardIndex(positive, 8).Should().BeInRange(0, 7);
+        ShardHash.GetShardIndex(negative, 16).Should().BeInRange(0, 15);
+        ShardHash.GetShardIndex4(positive).Should().Be(ShardHash.GetShardIndex(positive, 4));
+        ShardHash.GetShardIndex4(negative).Should().BeInRange(0, 3);
+    }
+
+    private sealed class ConstantHashStringComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string? x, string? y) => StringComparer.Ordinal.Equals(x, y);
+
+        public int GetHashCode(string obj) => 17;
+    }
+
+    private sealed class FixedHash
+    {
+        private readonly int _hashCode;
+
+        public FixedHash(int hashCode) => _hashCode = hashCode;
+
+        public override int GetHashCode() => _hashCode;
+    }
+}
+#endif

--- a/src/ReactiveList.Test/QuaternaryCollectionCoverageTests.cs
+++ b/src/ReactiveList.Test/QuaternaryCollectionCoverageTests.cs
@@ -1,0 +1,501 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET8_0_OR_GREATER || NETFRAMEWORK
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reflection;
+using System.Threading;
+using CP.Reactive.Collections;
+using CP.Reactive.Core;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace ReactiveList.Test;
+
+/// <summary>
+/// Covers quaternary list, dictionary, and base notification paths that are not reached by the public API tests.
+/// </summary>
+public class QuaternaryCollectionCoverageTests
+{
+    /// <summary>
+    /// Verifies QuaternaryList empty, enumerable, list, and secondary-index batch paths.
+    /// </summary>
+    [Test]
+    public void QuaternaryList_BatchOverloads_ShouldMaintainItemsIndexesAndVersion()
+    {
+        using var list = new QuaternaryList<int>();
+        var initialVersion = list.Version;
+
+        list.AddRange(Array.Empty<int>());
+        list.Count.Should().Be(0);
+        list.Version.Should().Be(initialVersion);
+
+        list.AddIndex("Parity", item => item % 2);
+        list.AddRange(Yield(0, 1, 2, 3, 4));
+        list.RemoveRange(Yield(1, 3));
+        list.AddRange(new List<int> { 10, 11 });
+        list.AddRange(new List<int>());
+        list.RemoveRange(Array.Empty<int>());
+        list.RemoveRange(new List<int>());
+        list.RemoveRange(new List<int> { 2 });
+
+        list.Count.Should().Be(4);
+        list.Should().BeEquivalentTo(new[] { 0, 4, 10, 11 });
+        list.GetItemsBySecondaryIndex("Parity", 0).Should().BeEquivalentTo(new[] { 0, 4, 10 });
+        list.GetItemsBySecondaryIndex("Parity", 1).Should().ContainSingle().Which.Should().Be(11);
+        list.Version.Should().BeGreaterThan(initialVersion);
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryList parallel array and list paths for large batch adds and removals.
+    /// </summary>
+    [Test]
+    public void QuaternaryList_LargeBatchOverloads_ShouldUseParallelPaths()
+    {
+        using var list = new QuaternaryList<int>();
+        list.AddIndex("Mod10", item => item % 10);
+
+        var firstBatch = Enumerable.Range(0, 300).ToArray();
+        list.AddRange(firstBatch);
+        list.RemoveRange(firstBatch.Where(item => item % 3 == 0).ToArray());
+
+        list.Count.Should().Be(200);
+        list.Contains(0).Should().BeFalse();
+        list.Contains(1).Should().BeTrue();
+
+        var secondBatch = Enumerable.Range(300, 300).ToList();
+        list.AddRange(secondBatch);
+        list.RemoveRange(secondBatch.Where(item => item % 2 == 0).ToList());
+
+        list.Contains(300).Should().BeFalse();
+        list.Contains(301).Should().BeTrue();
+        list.GetItemsBySecondaryIndex("Mod10", 1).Should().Contain(301);
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryList parallel paths when all items land in one shard, plus RemoveMany buffer growth.
+    /// </summary>
+    [Test]
+    public void QuaternaryList_SingleShardParallelBatchesAndRemoveManyGrowth_ShouldMaintainIndexes()
+    {
+        using var list = new QuaternaryList<ConstantShardItem>();
+        list.AddIndex("Parity", static item => item.Id % 2);
+
+        var arrayBatch = Enumerable.Range(0, 300).Select(static id => new ConstantShardItem(id)).ToArray();
+        list.AddRange(arrayBatch);
+        list.GetItemsBySecondaryIndex("Parity", 0).Should().HaveCount(150);
+        list.RemoveRange(arrayBatch);
+        list.Count.Should().Be(0);
+
+        var listBatch = Enumerable.Range(300, 300).Select(static id => new ConstantShardItem(id)).ToList();
+        list.AddRange(listBatch);
+        list.GetItemsBySecondaryIndex("Parity", 1).Should().HaveCount(150);
+        list.RemoveRange(listBatch);
+        list.Count.Should().Be(0);
+
+        list.AddRange(Enumerable.Range(600, 100).Select(static id => new ConstantShardItem(id)).ToArray());
+        list.RemoveMany(static _ => true).Should().Be(100);
+        list.Count.Should().Be(0);
+        list.GetItemsBySecondaryIndex("Parity", 0).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryList edit wrapper members and reflected members not exposed by ICollection.
+    /// </summary>
+    [Test]
+    public void QuaternaryList_EditWrapper_ShouldExposeCollectionMembers()
+    {
+        using var list = new QuaternaryList<int>();
+        list.AddIndex("Parity", item => item % 2);
+        list.AddRange(new[] { 1, 2, 3 });
+
+        list.Edit(editor =>
+        {
+            editor.Count.Should().Be(3);
+            editor.IsReadOnly.Should().BeFalse();
+            editor.Contains(2).Should().BeTrue();
+
+            var copy = new int[3];
+            editor.CopyTo(copy, 0);
+            copy.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            editor.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+
+            editor.Remove(1).Should().BeTrue();
+            editor.Remove(99).Should().BeFalse();
+            editor.Add(4);
+
+            var wrapperType = editor.GetType();
+            wrapperType.GetMethod("AddRange")!.Invoke(editor, new object[] { new[] { 5, 6 } });
+            wrapperType.GetProperty("Item")!.GetValue(editor, new object[] { 0 }).Should().NotBeNull();
+
+            Action badIndex = () => wrapperType.GetProperty("Item")!.GetValue(editor, new object[] { 999 });
+            Action replaceByIndex = () => wrapperType.GetProperty("Item")!.SetValue(editor, 7, new object[] { 0 });
+
+            badIndex.Should().Throw<TargetInvocationException>().WithInnerException<IndexOutOfRangeException>();
+            replaceByIndex.Should().Throw<TargetInvocationException>().WithInnerException<NotSupportedException>();
+        });
+
+        list.Should().BeEquivalentTo(new[] { 2, 3, 4, 5, 6 });
+        list.GetItemsBySecondaryIndex("Parity", 0).Should().BeEquivalentTo(new[] { 2, 4, 6 });
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryList snapshot and index guard paths.
+    /// </summary>
+    [Test]
+    public void QuaternaryList_SnapshotAndInvalidIndexes_ShouldBehaveAsExpected()
+    {
+        using var list = new QuaternaryList<int>();
+        list.AddRange(new[] { 0, 4, 8, 1 });
+
+        list.Snapshot().Should().BeEquivalentTo(list.ToArray());
+
+        Action negativeIndex = () => _ = list[-1];
+        Action tooHighIndex = () => _ = list[99];
+        Action setter = () => list[0] = 42;
+
+        negativeIndex.Should().Throw<IndexOutOfRangeException>();
+        tooHighIndex.Should().Throw<IndexOutOfRangeException>();
+        setter.Should().Throw<NotSupportedException>();
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryBase dispatches legacy collection changes through a captured synchronization context.
+    /// </summary>
+    [Test]
+    public void QuaternaryBase_CollectionChanged_ShouldUseCapturedSynchronizationContext()
+    {
+        var previousContext = SynchronizationContext.Current;
+        var context = new ImmediateSynchronizationContext();
+        SynchronizationContext.SetSynchronizationContext(context);
+
+        try
+        {
+            using var list = new QuaternaryList<int>();
+            using var reset = new ManualResetEventSlim(false);
+            NotifyCollectionChangedAction? action = null;
+
+            list.CollectionChanged += (_, args) =>
+            {
+                action = args.Action;
+                reset.Set();
+            };
+
+            list.Add(42);
+
+            reset.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
+            context.PostCount.Should().BeGreaterThan(0);
+            action.Should().Be(NotifyCollectionChangedAction.Reset);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(previousContext);
+        }
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryDictionary empty, enumerable, list, secondary-index, and view creation paths.
+    /// </summary>
+    [Test]
+    public void QuaternaryDictionary_BatchOverloadsAndViews_ShouldMaintainIndexes()
+    {
+        using var dictionary = new QuaternaryDictionary<int, string>();
+        var initialVersion = dictionary.Version;
+
+        dictionary.AddRange(Array.Empty<KeyValuePair<int, string>>());
+        dictionary.Version.Should().Be(initialVersion);
+
+        dictionary.AddRange(Yield(
+            new KeyValuePair<int, string>(1, "one"),
+            new KeyValuePair<int, string>(2, "two"),
+            new KeyValuePair<int, string>(3, "three")));
+        dictionary.AddValueIndex("Length", value => value.Length);
+
+        using var view = dictionary.CreateViewBySecondaryIndex("Length", 3, ImmediateScheduler.Instance, throttleMs: 1);
+        view.Count.Should().Be(2);
+
+        dictionary.AddRange(new List<KeyValuePair<int, string>>
+        {
+            new(4, "four"),
+            new(5, "five")
+        });
+        dictionary.Add(new KeyValuePair<int, string>(6, "six"));
+        dictionary.AddRange(new List<KeyValuePair<int, string>>());
+
+        dictionary.RemoveKeys(Yield(1));
+        dictionary.RemoveKeys(Array.Empty<int>());
+        dictionary.RemoveKeys(new List<int>());
+        dictionary.RemoveKeys(new List<int> { 4 });
+
+        dictionary.Count.Should().Be(4);
+        dictionary.ContainsKey(1).Should().BeFalse();
+        dictionary.ContainsKey(4).Should().BeFalse();
+        dictionary.GetValuesBySecondaryIndex("Length", 3).Should().BeEquivalentTo(new[] { "two", "six" });
+        dictionary.GetValuesBySecondaryIndex("Length", 4).Should().ContainSingle().Which.Should().Be("five");
+
+        Action missingIndex = () => dictionary.CreateViewBySecondaryIndex("Missing", 3, ImmediateScheduler.Instance);
+        Action incompatibleIndex = () => dictionary.CreateViewBySecondaryIndex("Length", "three", ImmediateScheduler.Instance);
+
+        missingIndex.Should().Throw<InvalidOperationException>();
+        incompatibleIndex.Should().Throw<InvalidOperationException>();
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryDictionary parallel array and list paths for large batch adds and key removals.
+    /// </summary>
+    [Test]
+    public void QuaternaryDictionary_LargeBatchOverloads_ShouldUseParallelPaths()
+    {
+        using var dictionary = new QuaternaryDictionary<int, string>();
+        dictionary.AddValueIndex("Length", value => value.Length);
+
+        var firstBatch = Enumerable.Range(0, 300)
+            .Select(i => new KeyValuePair<int, string>(i, $"value-{i}"))
+            .ToArray();
+
+        dictionary.AddRange(firstBatch);
+        dictionary.RemoveKeys(Enumerable.Range(0, 260).ToArray());
+
+        dictionary.Count.Should().Be(40);
+        dictionary.ContainsKey(0).Should().BeFalse();
+        dictionary.ContainsKey(299).Should().BeTrue();
+
+        var secondBatch = Enumerable.Range(300, 300)
+            .Select(i => new KeyValuePair<int, string>(i, $"value-{i}"))
+            .ToList();
+
+        dictionary.AddRange(secondBatch);
+        dictionary.RemoveKeys(secondBatch.Select(pair => pair.Key).Where(key => key % 2 == 0).ToList());
+
+        dictionary.ContainsKey(300).Should().BeFalse();
+        dictionary.ContainsKey(301).Should().BeTrue();
+        dictionary.GetValuesBySecondaryIndex("Length", "value-301".Length).Should().Contain("value-301");
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryDictionary parallel paths when all keys land in one shard, plus RemoveMany buffer growth.
+    /// </summary>
+    [Test]
+    public void QuaternaryDictionary_SingleShardParallelBatchesAndRemoveManyGrowth_ShouldMaintainIndexes()
+    {
+        using var dictionary = new QuaternaryDictionary<ConstantShardKey, string>();
+        dictionary.AddValueIndex("Length", static value => value.Length);
+
+        var arrayBatch = Enumerable.Range(0, 300)
+            .Select(static id => new KeyValuePair<ConstantShardKey, string>(new ConstantShardKey(id), $"v{id}"))
+            .ToArray();
+
+        dictionary.AddRange(arrayBatch);
+        dictionary.GetValuesBySecondaryIndex("Length", 2).Should().Contain("v0");
+        dictionary.RemoveKeys(arrayBatch.Select(static pair => pair.Key).ToArray());
+        dictionary.Count.Should().Be(0);
+
+        var listBatch = Enumerable.Range(300, 300)
+            .Select(static id => new KeyValuePair<ConstantShardKey, string>(new ConstantShardKey(id), $"v{id}"))
+            .ToList();
+
+        dictionary.AddRange(listBatch);
+        dictionary.GetValuesBySecondaryIndex("Length", 4).Should().Contain("v300");
+        dictionary.RemoveKeys(listBatch.ConvertAll(static pair => pair.Key));
+        dictionary.Count.Should().Be(0);
+
+        dictionary.AddRange(Enumerable.Range(600, 100)
+            .Select(static id => new KeyValuePair<ConstantShardKey, string>(new ConstantShardKey(id), $"v{id}"))
+            .ToArray());
+
+        dictionary.RemoveMany(static _ => true).Should().Be(100);
+        dictionary.Count.Should().Be(0);
+        dictionary.GetValuesBySecondaryIndex("Length", 4).Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryDictionary edit wrapper members and index maintenance.
+    /// </summary>
+    [Test]
+    public void QuaternaryDictionary_EditWrapper_ShouldExposeDictionaryMembers()
+    {
+        using var dictionary = new QuaternaryDictionary<int, string>();
+        dictionary.AddValueIndex("Length", value => value.Length);
+        dictionary.AddRange(new[]
+        {
+            new KeyValuePair<int, string>(1, "one"),
+            new KeyValuePair<int, string>(2, "two"),
+            new KeyValuePair<int, string>(3, "three")
+        });
+
+        dictionary.Edit(editor =>
+        {
+            editor.Count.Should().Be(3);
+            editor.IsReadOnly.Should().BeFalse();
+            editor.Keys.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            editor.Values.Should().BeEquivalentTo(new[] { "one", "two", "three" });
+            editor[1].Should().Be("one");
+
+            editor[1] = "ONE";
+            editor[4] = "four";
+            editor.Add(5, "five");
+            editor.Add(new KeyValuePair<int, string>(6, "six"));
+
+            editor.ContainsKey(6).Should().BeTrue();
+            editor.TryGetValue(6, out var six).Should().BeTrue();
+            six.Should().Be("six");
+            editor.Contains(new KeyValuePair<int, string>(6, "six")).Should().BeTrue();
+
+            var copy = new KeyValuePair<int, string>[editor.Count];
+            editor.CopyTo(copy, 0);
+            copy.Should().Contain(new KeyValuePair<int, string>(6, "six"));
+
+            ((IEnumerable)editor).GetEnumerator().MoveNext().Should().BeTrue();
+            editor.Remove(new KeyValuePair<int, string>(5, "wrong")).Should().BeFalse();
+            editor.Remove(new KeyValuePair<int, string>(5, "five")).Should().BeTrue();
+            editor.Remove(99).Should().BeFalse();
+
+            Action missingKey = () => _ = editor[99];
+            missingKey.Should().Throw<KeyNotFoundException>();
+        });
+
+        dictionary.Should().Contain(new KeyValuePair<int, string>(1, "ONE"));
+        dictionary.Should().Contain(new KeyValuePair<int, string>(4, "four"));
+        dictionary.Should().Contain(new KeyValuePair<int, string>(6, "six"));
+        dictionary.ContainsKey(5).Should().BeFalse();
+        dictionary.GetValuesBySecondaryIndex("Length", 3).Should().BeEquivalentTo(new[] { "ONE", "two", "six" });
+    }
+
+    /// <summary>
+    /// Verifies QuaternaryDictionary guard paths and legacy collection changed update notifications.
+    /// </summary>
+    [Test]
+    public void QuaternaryDictionary_GuardsAndCollectionChanged_ShouldBehaveAsExpected()
+    {
+        using var dictionary = new QuaternaryDictionary<int, string>();
+
+        dictionary.Add(1, "one");
+        dictionary.Contains(new KeyValuePair<int, string>(1, "uno")).Should().BeFalse();
+        dictionary.Remove(new KeyValuePair<int, string>(1, "uno")).Should().BeFalse();
+
+        Action duplicate = () => dictionary.Add(1, "duplicate");
+        Action missingIndexer = () => _ = dictionary[99];
+        Action nullCopy = () => dictionary.CopyTo(null!, 0);
+        Action nullRemoveKeys = () => dictionary.RemoveKeys(null!);
+        Action nullRemoveMany = () => dictionary.RemoveMany(null!);
+        Action nullEdit = () => dictionary.Edit(null!);
+
+        duplicate.Should().Throw<ArgumentException>();
+        missingIndexer.Should().Throw<KeyNotFoundException>();
+        nullCopy.Should().Throw<ArgumentNullException>();
+        nullRemoveKeys.Should().Throw<ArgumentNullException>();
+        nullRemoveMany.Should().Throw<ArgumentNullException>();
+        nullEdit.Should().Throw<ArgumentNullException>();
+
+        using var reset = new ManualResetEventSlim(false);
+        NotifyCollectionChangedAction? action = null;
+
+        dictionary.CollectionChanged += (_, args) =>
+        {
+            action = args.Action;
+            reset.Set();
+        };
+
+        dictionary[1] = "ONE";
+
+        reset.Wait(TimeSpan.FromSeconds(2)).Should().BeTrue();
+        action.Should().Be(NotifyCollectionChangedAction.Reset);
+    }
+
+    /// <summary>
+    /// Verifies protected QuaternaryBase batch helpers and null guard paths through a minimal harness.
+    /// </summary>
+    [Test]
+    public void QuaternaryBase_BatchHelpers_ShouldEmitAndValidateArguments()
+    {
+        using var harness = new QuaternaryBaseHarness();
+        var received = new List<CacheNotify<int>>();
+        using var subscription = harness.Stream.Subscribe(received.Add);
+
+        harness.EmitDirect(new[] { 1, 2 });
+        harness.EmitAddedFromList(new List<int> { 3, 4 });
+        harness.EmitRemovedFromList(new List<int> { 5, 6 });
+        SpinWait.SpinUntil(() => received.Count >= 3, TimeSpan.FromSeconds(2)).Should().BeTrue();
+
+        received.Select(static notification => notification.Action)
+            .Should().Equal(CacheAction.BatchOperation, CacheAction.BatchAdded, CacheAction.BatchRemoved);
+        received.Select(static notification => notification.Batch!.Count)
+            .Should().Equal(2, 2, 2);
+
+        Action nullAdded = () => harness.EmitAddedFromList(null!);
+        Action nullRemoved = () => harness.EmitRemovedFromList(null!);
+
+        nullAdded.Should().Throw<ArgumentNullException>().WithParameterName("items");
+        nullRemoved.Should().Throw<ArgumentNullException>().WithParameterName("items");
+
+        foreach (var notification in received)
+        {
+            notification.Batch!.Dispose();
+        }
+    }
+
+    private static IEnumerable<T> Yield<T>(params T[] items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+
+    private sealed class ImmediateSynchronizationContext : SynchronizationContext
+    {
+        private int _postCount;
+
+        public int PostCount => Volatile.Read(ref _postCount);
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            Interlocked.Increment(ref _postCount);
+            d(state);
+        }
+    }
+
+    private sealed class ConstantShardItem : IEquatable<ConstantShardItem>
+    {
+        public ConstantShardItem(int id) => Id = id;
+
+        public int Id { get; }
+
+        public bool Equals(ConstantShardItem? other) => other is not null && Id == other.Id;
+
+        public override bool Equals(object? obj) => Equals(obj as ConstantShardItem);
+
+        public override int GetHashCode() => 0;
+    }
+
+    private sealed class ConstantShardKey : IEquatable<ConstantShardKey>
+    {
+        public ConstantShardKey(int id) => Id = id;
+
+        public int Id { get; }
+
+        public bool Equals(ConstantShardKey? other) => other is not null && Id == other.Id;
+
+        public override bool Equals(object? obj) => Equals(obj as ConstantShardKey);
+
+        public override int GetHashCode() => 0;
+    }
+
+    private sealed class QuaternaryBaseHarness : QuaternaryBase<int, QuadList<int>, int>
+    {
+        public void EmitDirect(int[] items) => EmitBatchDirect(items, items.Length);
+
+        public void EmitAddedFromList(IList<int> items) => EmitBatchAddedFromList(items, items?.Count ?? 0);
+
+        public void EmitRemovedFromList(IList<int> items) => EmitBatchRemovedFromList(items, items?.Count ?? 0);
+
+        public override IEnumerator<int> GetEnumerator() => Enumerable.Empty<int>().GetEnumerator();
+    }
+}
+#endif

--- a/src/ReactiveList.Test/QuaternaryDictionaryExtensionsTests.cs
+++ b/src/ReactiveList.Test/QuaternaryDictionaryExtensionsTests.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System.Collections.Generic;
 using System.Reactive.Concurrency;
 using System.Threading.Tasks;
 using CP.Reactive;
 using CP.Reactive.Collections;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -19,7 +19,7 @@ public class QuaternaryDictionaryExtensionsTests
     /// <summary>
     /// Verifies that CreateView returns a view with all items when no filter is applied.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateView_WithoutFilter_ShouldContainAllItems()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -37,7 +37,7 @@ public class QuaternaryDictionaryExtensionsTests
     /// <summary>
     /// Verifies that CreateView with filter returns only matching items.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateView_WithFilter_ShouldContainOnlyMatchingItems()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -57,7 +57,7 @@ public class QuaternaryDictionaryExtensionsTests
     /// <summary>
     /// Verifies that CreateViewBySecondaryIndex filters items by the secondary value index key.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateViewBySecondaryIndex_ShouldFilterByKey()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();
@@ -77,7 +77,7 @@ public class QuaternaryDictionaryExtensionsTests
     /// <summary>
     /// Verifies that CreateViewBySecondaryIndex with multiple keys includes items matching any key.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateViewBySecondaryIndex_WithMultipleKeys_ShouldIncludeAllMatches()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();
@@ -97,7 +97,7 @@ public class QuaternaryDictionaryExtensionsTests
     /// <summary>
     /// Verifies that ToProperty sets the property correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void ToProperty_ShouldSetProperty()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -119,7 +119,7 @@ public class QuaternaryDictionaryExtensionsTests
     /// Verifies that ReactiveView updates when items are added to the source dictionary.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Test]
     public async Task ReactiveView_ShouldUpdateOnAdd()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -138,7 +138,7 @@ public class QuaternaryDictionaryExtensionsTests
     /// Verifies that ReactiveView updates when items are removed from the source dictionary.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Test]
     public async Task ReactiveView_ShouldUpdateOnRemove()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -166,7 +166,7 @@ public class QuaternaryDictionaryExtensionsTests
     /// Verifies that CreateViewBySecondaryIndex updates when new matching items are added.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Test]
     public async Task CreateViewBySecondaryIndex_ShouldUpdateOnAdd()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();
@@ -189,7 +189,7 @@ public class QuaternaryDictionaryExtensionsTests
     /// Verifies that CreateViewBySecondaryIndex doesn't include non-matching items when added.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Test]
     public async Task CreateViewBySecondaryIndex_ShouldNotIncludeNonMatchingItems()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();

--- a/src/ReactiveList.Test/QuaternaryDictionaryTests.cs
+++ b/src/ReactiveList.Test/QuaternaryDictionaryTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETFRAMEWORK
 
 using System;
 using System.Collections.Concurrent;
@@ -12,7 +12,7 @@ using System.Threading;
 using CP.Reactive.Collections;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -31,7 +31,7 @@ public class QuaternaryDictionaryTests
     /// </summary>
     /// <remarks>This test ensures that adding a key-value pair stores the value, updating the value via the
     /// indexer replaces the existing value, and the dictionary maintains the correct count and key presence.</remarks>
-    [Fact]
+    [Test]
     public void AddAndIndexer_ShouldStoreAndUpdateValues()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -53,7 +53,7 @@ public class QuaternaryDictionaryTests
     /// </summary>
     /// <remarks>This test ensures that when an attempt is made to add a key that already exists in the
     /// dictionary, TryAdd returns <see langword="false"/> and does not overwrite the existing value.</remarks>
-    [Fact]
+    [Test]
     public void TryAdd_ShouldPreventDuplicateKeys()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -71,7 +71,7 @@ public class QuaternaryDictionaryTests
     /// <remarks>This test ensures that the observable stream associated with the dictionary emits a
     /// CacheAction.Added event when a new entry is added and a CacheAction.Updated event when an existing entry is
     /// updated. It also verifies that the final value for the key reflects the most recent update.</remarks>
-    [Fact]
+    [Test]
     public void AddOrUpdate_ShouldEmitCorrectActions()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -101,7 +101,7 @@ public class QuaternaryDictionaryTests
     /// <remarks>This test ensures that the Remove method returns <see langword="true"/> when an existing key
     /// is removed and <see langword="false"/> when attempting to remove a key that is not present in the
     /// dictionary.</remarks>
-    [Fact]
+    [Test]
     public void Remove_ShouldRemoveExistingAndReturnFalseForMissing()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -119,7 +119,7 @@ public class QuaternaryDictionaryTests
     /// <remarks>This test ensures that the AddRange method triggers a batch added event on the Stream,
     /// and that the dictionary's Keys and Values properties reflect the newly added items. It also checks that the
     /// batch notification contains all added items and that the dictionary's count is updated accordingly.</remarks>
-    [Fact]
+    [Test]
     public void AddRange_ShouldEmitBatchAndExposeKeysAndValues()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -159,7 +159,7 @@ public class QuaternaryDictionaryTests
     /// <remarks>This test ensures that the CopyTo method correctly transfers all key-value pairs to the
     /// target array without omitting or duplicating entries. It also checks that the entries are placed at the correct
     /// position in the array.</remarks>
-    [Fact]
+    [Test]
     public void CopyTo_ShouldCopyAllEntries()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -170,7 +170,7 @@ public class QuaternaryDictionaryTests
 
         dict.CopyTo(array, 1);
 
-        array[1..].Should().BeEquivalentTo(dict.ToArray());
+        array.Skip(1).Should().BeEquivalentTo(dict.ToArray());
     }
 
     /// <summary>
@@ -179,7 +179,7 @@ public class QuaternaryDictionaryTests
     /// <remarks>This test ensures that when items are added to or removed from the dictionary, the associated
     /// value index reflects these changes as expected. It also verifies that clearing the dictionary updates the value
     /// index accordingly.</remarks>
-    [Fact]
+    [Test]
     public void ValueIndex_ShouldTrackAddsAndRemovals()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -205,7 +205,7 @@ public class QuaternaryDictionaryTests
     /// <summary>
     /// Verifies that the Lookup method returns the correct result for existing and non-existing keys.
     /// </summary>
-    [Fact]
+    [Test]
     public void Lookup_ShouldReturnCorrectResult()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -224,7 +224,7 @@ public class QuaternaryDictionaryTests
     /// <summary>
     /// Verifies that RemoveKeys removes multiple keys in a batch operation.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveKeys_ShouldRemoveMultipleKeysAndEmitBatch()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -260,7 +260,7 @@ public class QuaternaryDictionaryTests
     /// <summary>
     /// Verifies that RemoveMany with a predicate removes matching entries.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveMany_WithPredicate_ShouldRemoveMatchingEntries()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -282,7 +282,7 @@ public class QuaternaryDictionaryTests
     /// <summary>
     /// Verifies that the Edit method allows batch modifications with a single notification.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldPerformBatchModificationsWithSingleNotification()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -320,7 +320,7 @@ public class QuaternaryDictionaryTests
     /// <summary>
     /// Verifies that Edit updates value indices correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldUpdateValueIndicesCorrectly()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -346,7 +346,7 @@ public class QuaternaryDictionaryTests
     /// <summary>
     /// Verifies that GetValuesBySecondaryIndex returns matching values.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetValuesBySecondaryIndex_ShouldReturnMatchingValues()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -371,7 +371,7 @@ public class QuaternaryDictionaryTests
     /// <summary>
     /// Verifies that GetValuesBySecondaryIndex returns empty for non-existent index.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetValuesBySecondaryIndex_WithNonExistentIndex_ShouldReturnEmpty()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -384,7 +384,7 @@ public class QuaternaryDictionaryTests
     /// <summary>
     /// Verifies that ValueMatchesSecondaryIndex returns correct results.
     /// </summary>
-    [Fact]
+    [Test]
     public void ValueMatchesSecondaryIndex_ShouldReturnCorrectResult()
     {
         using var dict = new QuaternaryDictionary<int, string>();
@@ -399,7 +399,7 @@ public class QuaternaryDictionaryTests
     /// <summary>
     /// Verifies that GetValuesBySecondaryIndex updates after additions and removals.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetValuesBySecondaryIndex_ShouldUpdateAfterAdditionsAndRemovals()
     {
         using var dict = new QuaternaryDictionary<int, string>();

--- a/src/ReactiveList.Test/QuaternaryExtensionsAdditionalTests.cs
+++ b/src/ReactiveList.Test/QuaternaryExtensionsAdditionalTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 using CP.Reactive;
 using CP.Reactive.Collections;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -25,7 +25,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// Tests that CreateViewBySecondaryIndex with observable keys rebuilds when keys change.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task CreateViewBySecondaryIndex_WithObservableKeys_RebuildsWhenKeysChange()
     {
         // Arrange
@@ -93,7 +93,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// Tests that CreateViewBySecondaryIndex with observable keys handles empty key array.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task CreateViewBySecondaryIndex_WithObservableKeys_HandlesEmptyKeyArray()
     {
         // Arrange
@@ -124,7 +124,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// <summary>
     /// Tests that CreateViewBySecondaryIndex throws for null list.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateViewBySecondaryIndex_ThrowsForNullList()
     {
         // Arrange
@@ -138,7 +138,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// <summary>
     /// Tests that CreateViewBySecondaryIndex throws for null index name.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateViewBySecondaryIndex_ThrowsForNullIndexName()
     {
         // Arrange
@@ -154,7 +154,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// Tests that views handle rapid key changes gracefully.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task CreateViewBySecondaryIndex_HandlesRapidKeyChanges()
     {
         // Arrange
@@ -187,7 +187,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// Tests a real-world scenario of filtering employees by multiple criteria.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task RealWorldScenario_EmployeeFilteringByDepartment()
     {
         // Arrange - Company employee directory
@@ -241,7 +241,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// Tests dictionary CreateViewBySecondaryIndex with single key.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task Dictionary_CreateViewBySecondaryIndex_FiltersByValueIndexKey()
     {
         // Arrange
@@ -266,7 +266,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// Tests dictionary CreateViewBySecondaryIndex with multiple keys via extension method.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task Dictionary_CreateViewBySecondaryIndex_HandlesMultipleIndexKeys()
     {
         // Arrange
@@ -290,7 +290,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// Tests dictionary CreateViewBySecondaryIndex with observable keys.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task Dictionary_CreateViewBySecondaryIndex_WithObservableKeys_RebuildsWhenKeysChange()
     {
         // Arrange
@@ -320,7 +320,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// <summary>
     /// Tests that DynamicSecondaryIndexReactiveView initializes correctly with direct construction.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicSecondaryIndexReactiveView_DirectConstruction_InitializesCorrectly()
     {
         // Arrange
@@ -354,7 +354,7 @@ public class QuaternaryExtensionsAdditionalTests
     /// <summary>
     /// Tests that CreateDynamicViewBySecondaryIndex extension method works same as direct construction.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateDynamicViewBySecondaryIndex_ExtensionMethod_WorksCorrectly()
     {
         // Arrange

--- a/src/ReactiveList.Test/QuaternaryExtensionsTests.cs
+++ b/src/ReactiveList.Test/QuaternaryExtensionsTests.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System.Reactive.Concurrency;
 using System.Threading.Tasks;
 using CP.Reactive;
 using CP.Reactive.Collections;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -18,7 +18,7 @@ public class QuaternaryExtensionsTests
     /// <summary>
     /// Verifies that CreateView returns a view with all items when no filter is applied.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateView_WithoutFilter_ShouldContainAllItems()
     {
         using var list = new QuaternaryList<int>();
@@ -32,7 +32,7 @@ public class QuaternaryExtensionsTests
     /// <summary>
     /// Verifies that CreateView with filter returns only matching items.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateView_WithFilter_ShouldContainOnlyMatchingItems()
     {
         using var list = new QuaternaryList<int>();
@@ -48,7 +48,7 @@ public class QuaternaryExtensionsTests
     /// <summary>
     /// Verifies that CreateViewBySecondaryIndex filters items by the secondary index key.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateViewBySecondaryIndex_ShouldFilterByKey()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -68,7 +68,7 @@ public class QuaternaryExtensionsTests
     /// <summary>
     /// Verifies that CreateViewBySecondaryIndex with multiple keys includes items matching any key.
     /// </summary>
-    [Fact]
+    [Test]
     public void CreateViewBySecondaryIndex_WithMultipleKeys_ShouldIncludeAllMatches()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -88,7 +88,7 @@ public class QuaternaryExtensionsTests
     /// <summary>
     /// Verifies that ToProperty sets the property correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void ToProperty_ShouldSetProperty()
     {
         using var list = new QuaternaryList<int>();
@@ -106,7 +106,7 @@ public class QuaternaryExtensionsTests
     /// Verifies that ReactiveView updates when items are added to the source list.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Test]
     public async Task ReactiveView_ShouldUpdateOnAdd()
     {
         using var list = new QuaternaryList<int>();
@@ -125,7 +125,7 @@ public class QuaternaryExtensionsTests
     /// Verifies that ReactiveView updates when items are removed from the source list.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Test]
     public async Task ReactiveView_ShouldUpdateOnRemove()
     {
         using var list = new QuaternaryList<int>();
@@ -149,7 +149,7 @@ public class QuaternaryExtensionsTests
     /// Verifies that ReactiveView updates when RemoveRange is called.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Test]
     public async Task ReactiveView_ShouldUpdateOnRemoveRange()
     {
         using var list = new QuaternaryList<int>();
@@ -174,7 +174,7 @@ public class QuaternaryExtensionsTests
     /// Verifies that CreateViewBySecondaryIndex updates when new matching items are added.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Test]
     public async Task CreateViewBySecondaryIndex_ShouldUpdateOnAdd()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -197,7 +197,7 @@ public class QuaternaryExtensionsTests
     /// Verifies that CreateViewBySecondaryIndex doesn't include non-matching items when added.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>
-    [Fact]
+    [Test]
     public async Task CreateViewBySecondaryIndex_ShouldNotIncludeNonMatchingItems()
     {
         using var list = new QuaternaryList<TestPerson>();

--- a/src/ReactiveList.Test/QuaternaryListTests.cs
+++ b/src/ReactiveList.Test/QuaternaryListTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,7 +9,7 @@ using System.Reactive.Linq;
 using System.Threading;
 using CP.Reactive.Collections;
 using CP.Reactive.Core;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -24,7 +24,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that adding an item to a QuaternaryList increases the count and that the item is present in the list.
     /// </summary>
-    [Fact]
+    [Test]
     public void Add_ShouldIncreaseCountAndContainItem()
     {
         using var list = new QuaternaryList<int>();
@@ -39,7 +39,7 @@ public class QuaternaryListTests
     /// Verifies that the AddRange method emits a batch notification and correctly copies the added items to the
     /// underlying collection.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_ShouldEmitBatchAndCopyItems()
     {
         using var list = new QuaternaryList<int>();
@@ -73,7 +73,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that the indexer of the QuaternaryList returns the correct items across multiple shards.
     /// </summary>
-    [Fact]
+    [Test]
     public void Indexer_ShouldReturnItemsAcrossShards()
     {
         using var list = new QuaternaryList<int>();
@@ -90,7 +90,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that setting an item via the indexer throws NotSupportedException.
     /// </summary>
-    [Fact]
+    [Test]
     public void IndexerSetter_ShouldThrowNotSupportedException()
     {
         using var list = new QuaternaryList<int> { 1, 2, 3 };
@@ -102,7 +102,7 @@ public class QuaternaryListTests
     /// Verifies that adding an index to a QuaternaryList and querying by that index correctly tracks and updates
     /// results as items are added and removed.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddIndexAndQuery_ShouldTrackAndUpdate()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -133,7 +133,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that calling Clear on a QuaternaryList resets the item collection and all associated indices.
     /// </summary>
-    [Fact]
+    [Test]
     public void Clear_ShouldResetItemsAndIndices()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -153,7 +153,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that the RemoveRange method removes the specified items from the list and emits a batch removed notification.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveRange_ShouldRemoveItemsAndEmitBatchRemoved()
     {
         using var list = new QuaternaryList<int>();
@@ -189,7 +189,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that RemoveMany with a predicate removes matching items and emits a batch removed notification.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveMany_WithPredicate_ShouldRemoveMatchingItems()
     {
         using var list = new QuaternaryList<int>();
@@ -220,7 +220,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that the Edit method allows batch modifications with a single notification.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldPerformBatchModificationsWithSingleNotification()
     {
         using var list = new QuaternaryList<int>();
@@ -258,7 +258,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that Edit updates indices correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldUpdateIndicesCorrectly()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -288,7 +288,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that Remove returns true when item exists and false when it doesn't.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldReturnCorrectResult()
     {
         using var list = new QuaternaryList<int>();
@@ -302,7 +302,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that Contains returns correct results.
     /// </summary>
-    [Fact]
+    [Test]
     public void Contains_ShouldReturnCorrectResult()
     {
         using var list = new QuaternaryList<int>();
@@ -315,7 +315,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that CopyTo copies all items to the target array.
     /// </summary>
-    [Fact]
+    [Test]
     public void CopyTo_ShouldCopyAllItems()
     {
         using var list = new QuaternaryList<int>();
@@ -335,7 +335,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that GetEnumerator iterates over all items.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetEnumerator_ShouldIterateAllItems()
     {
         using var list = new QuaternaryList<int>();
@@ -354,7 +354,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that IsReadOnly returns false.
     /// </summary>
-    [Fact]
+    [Test]
     public void IsReadOnly_ShouldReturnFalse()
     {
         using var list = new QuaternaryList<int>();
@@ -364,7 +364,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that ItemMatchesSecondaryIndex returns correct results.
     /// </summary>
-    [Fact]
+    [Test]
     public void ItemMatchesSecondaryIndex_ShouldReturnCorrectResult()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -383,7 +383,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that GetItemsBySecondaryIndex returns empty when index doesn't exist.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetItemsBySecondaryIndex_WithNonExistentIndex_ShouldReturnEmpty()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -394,7 +394,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that Stream emits Added notification for single item add.
     /// </summary>
-    [Fact]
+    [Test]
     public void Stream_ShouldEmitAddedNotification()
     {
         using var list = new QuaternaryList<int>();
@@ -417,7 +417,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that Stream emits Removed notification for single item remove.
     /// </summary>
-    [Fact]
+    [Test]
     public void Stream_ShouldEmitRemovedNotification()
     {
         using var list = new QuaternaryList<int>();
@@ -445,7 +445,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that Stream emits Cleared notification.
     /// </summary>
-    [Fact]
+    [Test]
     public void Stream_ShouldEmitClearedNotification()
     {
         using var list = new QuaternaryList<int>();
@@ -472,7 +472,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that ReplaceAll replaces all items atomically.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReplaceAll_ShouldReplaceAllItemsAtomically()
     {
         using var list = new QuaternaryList<int>();
@@ -491,7 +491,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that ReplaceAll emits a single batch notification.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReplaceAll_ShouldEmitSingleBatchNotification()
     {
         using var list = new QuaternaryList<int>();
@@ -513,7 +513,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that ReplaceAll with empty collection clears the list.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReplaceAll_WithEmptyCollection_ShouldClearList()
     {
         using var list = new QuaternaryList<int>();
@@ -527,7 +527,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that ReplaceAll updates secondary indices correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReplaceAll_ShouldUpdateSecondaryIndices()
     {
         using var list = new QuaternaryList<int>();
@@ -547,7 +547,7 @@ public class QuaternaryListTests
     /// <summary>
     /// Verifies that ReplaceAll throws ArgumentNullException when items is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReplaceAll_WithNull_ShouldThrowArgumentNullException()
     {
         using var list = new QuaternaryList<int>();

--- a/src/ReactiveList.Test/Reactive2DListTests.cs
+++ b/src/ReactiveList.Test/Reactive2DListTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using CP.Reactive.Collections;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -18,7 +18,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Constructors the should initialize empty list.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_ShouldInitializeEmptyList()
     {
         var list = new Reactive2DList<int>();
@@ -29,7 +29,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Constructors the should initialize with items.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_ShouldInitializeWithItems()
     {
         var items = new List<List<int>> { new() { 1, 2 }, new() { 3, 4 } };
@@ -43,7 +43,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Constructors the should initialize with reactive lists.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_ShouldInitializeWithReactiveLists()
     {
         var items = new List<ReactiveList<int>> { new() { 1, 2 }, new() { 3, 4 } };
@@ -57,7 +57,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Constructors the should initialize with single item.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_ShouldInitializeWithSingleItem()
     {
         var list = new Reactive2DList<int>(5);
@@ -70,7 +70,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Constructors the should initialize with items.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_ShouldInitializeWithReactiveList()
     {
         var items = new ReactiveList<int> { 1, 2, 3, 4 };
@@ -83,7 +83,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Adds the range should add items.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_ShouldAddItems()
     {
         var list = new Reactive2DList<int>();
@@ -96,7 +96,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Adds the range should add single items.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_ShouldAddSingleItems()
     {
         var list = new Reactive2DList<int>();
@@ -109,7 +109,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Adds the index of the range should insert items at.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_ShouldInsertItemsAtIndex()
     {
         var list = new Reactive2DList<int>(new List<int> { 5 });
@@ -127,7 +127,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Inserts the index of the should insert items at.
     /// </summary>
-    [Fact]
+    [Test]
     public void Insert_ShouldInsertItemsAtIndex()
     {
         var list = new Reactive2DList<int>(new List<int> { 5 });
@@ -143,7 +143,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Inserts the index of the should insert single item at.
     /// </summary>
-    [Fact]
+    [Test]
     public void Insert_ShouldInsertSingleItemAtIndex()
     {
         var list = new Reactive2DList<int>(new List<int> { 5 });
@@ -156,7 +156,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Inserts the index of the should insert reactive list at.
     /// </summary>
-    [Fact]
+    [Test]
     public void Insert_ShouldInsertReactiveListAtIndex()
     {
         var list = new Reactive2DList<int>(new List<int> { 5 });
@@ -170,7 +170,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Inserts the index of the should insert items in reactive list at.
     /// </summary>
-    [Fact]
+    [Test]
     public void Insert_ShouldInsertItemsInReactiveListAtIndex()
     {
         var list = new Reactive2DList<int>(new List<int> { 5 });
@@ -188,7 +188,7 @@ public class Reactive2DListTests
     /// <summary>
     /// GetItem should return item at specified indices.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetItem_ShouldReturnItemAtSpecifiedIndices()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2, 3 }, new() { 4, 5, 6 } });
@@ -202,7 +202,7 @@ public class Reactive2DListTests
     /// <summary>
     /// GetItem should throw when outer index is negative.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetItem_ShouldThrowWhenOuterIndexIsNegative()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -217,7 +217,7 @@ public class Reactive2DListTests
     /// <summary>
     /// GetItem should throw when outer index exceeds count.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetItem_ShouldThrowWhenOuterIndexExceedsCount()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -232,7 +232,7 @@ public class Reactive2DListTests
     /// <summary>
     /// GetItem should throw when inner index is negative.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetItem_ShouldThrowWhenInnerIndexIsNegative()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -247,7 +247,7 @@ public class Reactive2DListTests
     /// <summary>
     /// GetItem should throw when inner index exceeds count.
     /// </summary>
-    [Fact]
+    [Test]
     public void GetItem_ShouldThrowWhenInnerIndexExceedsCount()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -262,7 +262,7 @@ public class Reactive2DListTests
     /// <summary>
     /// SetItem should update item at specified indices.
     /// </summary>
-    [Fact]
+    [Test]
     public void SetItem_ShouldUpdateItemAtSpecifiedIndices()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2, 3 }, new() { 4, 5, 6 } });
@@ -276,7 +276,7 @@ public class Reactive2DListTests
     /// <summary>
     /// SetItem should throw when outer index is out of range.
     /// </summary>
-    [Fact]
+    [Test]
     public void SetItem_ShouldThrowWhenOuterIndexIsOutOfRange()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -291,7 +291,7 @@ public class Reactive2DListTests
     /// <summary>
     /// SetItem should throw when inner index is out of range.
     /// </summary>
-    [Fact]
+    [Test]
     public void SetItem_ShouldThrowWhenInnerIndexIsOutOfRange()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -306,7 +306,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Flatten should return all items in order.
     /// </summary>
-    [Fact]
+    [Test]
     public void Flatten_ShouldReturnAllItemsInOrder()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 }, new() { 3, 4 }, new() { 5, 6 } });
@@ -321,7 +321,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Flatten should return empty for empty list.
     /// </summary>
-    [Fact]
+    [Test]
     public void Flatten_ShouldReturnEmptyForEmptyList()
     {
         var list = new Reactive2DList<int>();
@@ -335,7 +335,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Flatten should handle empty inner lists.
     /// </summary>
-    [Fact]
+    [Test]
     public void Flatten_ShouldHandleEmptyInnerLists()
     {
         var list = new Reactive2DList<int>
@@ -355,7 +355,7 @@ public class Reactive2DListTests
     /// <summary>
     /// TotalCount should return sum of all inner list counts.
     /// </summary>
-    [Fact]
+    [Test]
     public void TotalCount_ShouldReturnSumOfAllInnerListCounts()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 }, new() { 3, 4, 5 }, new() { 6 } });
@@ -369,7 +369,7 @@ public class Reactive2DListTests
     /// <summary>
     /// TotalCount should return zero for empty list.
     /// </summary>
-    [Fact]
+    [Test]
     public void TotalCount_ShouldReturnZeroForEmptyList()
     {
         var list = new Reactive2DList<int>();
@@ -383,7 +383,7 @@ public class Reactive2DListTests
     /// <summary>
     /// TotalCount should handle empty inner lists.
     /// </summary>
-    [Fact]
+    [Test]
     public void TotalCount_ShouldHandleEmptyInnerLists()
     {
         var list = new Reactive2DList<int>
@@ -402,7 +402,7 @@ public class Reactive2DListTests
     /// <summary>
     /// AddToInner should add items to specified inner list.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddToInner_ShouldAddItemsToSpecifiedInnerList()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 }, new() { 3, 4 } });
@@ -418,7 +418,7 @@ public class Reactive2DListTests
     /// <summary>
     /// AddToInner should add single item to specified inner list.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddToInner_ShouldAddSingleItemToSpecifiedInnerList()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 }, new() { 3, 4 } });
@@ -433,7 +433,7 @@ public class Reactive2DListTests
     /// <summary>
     /// AddToInner should throw when outer index is out of range.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddToInner_ShouldThrowWhenOuterIndexIsOutOfRange()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -448,7 +448,7 @@ public class Reactive2DListTests
     /// <summary>
     /// AddToInner should throw when items is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddToInner_ShouldThrowWhenItemsIsNull()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -463,7 +463,7 @@ public class Reactive2DListTests
     /// <summary>
     /// RemoveFromInner should remove item at specified indices.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveFromInner_ShouldRemoveItemAtSpecifiedIndices()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2, 3 }, new() { 4, 5, 6 } });
@@ -479,7 +479,7 @@ public class Reactive2DListTests
     /// <summary>
     /// RemoveFromInner should throw when outer index is out of range.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveFromInner_ShouldThrowWhenOuterIndexIsOutOfRange()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -494,7 +494,7 @@ public class Reactive2DListTests
     /// <summary>
     /// ClearInner should clear the specified inner list.
     /// </summary>
-    [Fact]
+    [Test]
     public void ClearInner_ShouldClearTheSpecifiedInnerList()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2, 3 }, new() { 4, 5, 6 } });
@@ -509,7 +509,7 @@ public class Reactive2DListTests
     /// <summary>
     /// ClearInner should throw when outer index is out of range.
     /// </summary>
-    [Fact]
+    [Test]
     public void ClearInner_ShouldThrowWhenOuterIndexIsOutOfRange()
     {
         var list = new Reactive2DList<int>(new List<List<int>> { new() { 1, 2 } });
@@ -524,7 +524,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Constructor should throw when items enumerable is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_ShouldThrowWhenItemsEnumerableIsNull()
     {
         var action = () => new Reactive2DList<int>((IEnumerable<IEnumerable<int>>)null!);
@@ -536,7 +536,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Constructor should throw when reactive list item is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_ShouldThrowWhenReactiveListItemIsNull()
     {
         var action = () => new Reactive2DList<int>((ReactiveList<int>)null!);
@@ -548,7 +548,7 @@ public class Reactive2DListTests
     /// <summary>
     /// AddRange with nested enumerable should throw when null.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_NestedEnumerable_ShouldThrowWhenNull()
     {
         var list = new Reactive2DList<int>();
@@ -563,7 +563,7 @@ public class Reactive2DListTests
     /// <summary>
     /// AddRange with single enumerable should throw when null.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_SingleEnumerable_ShouldThrowWhenNull()
     {
         var list = new Reactive2DList<int>();
@@ -578,7 +578,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Insert with enumerable should throw when null.
     /// </summary>
-    [Fact]
+    [Test]
     public void Insert_Enumerable_ShouldThrowWhenNull()
     {
         var list = new Reactive2DList<int>(new List<int> { 1 });
@@ -593,7 +593,7 @@ public class Reactive2DListTests
     /// <summary>
     /// Insert with inner index should throw when items null.
     /// </summary>
-    [Fact]
+    [Test]
     public void Insert_WithInnerIndex_ShouldThrowWhenItemsNull()
     {
         var list = new Reactive2DList<int>(new List<int> { 1 });

--- a/src/ReactiveList.Test/ReactiveList.Tests.csproj
+++ b/src/ReactiveList.Test/ReactiveList.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0;net10.0-windows10.0.17763.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net462;net48;net481;net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0;net10.0-windows10.0.17763.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>

--- a/src/ReactiveList.Test/ReactiveListAddTests.cs
+++ b/src/ReactiveList.Test/ReactiveListAddTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CP.Reactive.Collections;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -19,7 +19,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add array item].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddArrayItem()
     {
         ReactiveList<string> fixture = [];
@@ -32,7 +32,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add complex array item].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddComplexArrayItem()
     {
         ReactiveList<TestData> fixture = [];
@@ -45,7 +45,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add multiple single complex items].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddMultipleSingleComplexItems()
     {
         ReactiveList<TestData> fixture = [];
@@ -62,7 +62,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add multiple single complex items and edit].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddMultipleSingleComplexItemsAndEdit()
     {
         ReactiveList<string> fixture = [];
@@ -81,7 +81,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add multiple single items].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddMultipleSingleItems()
     {
         ReactiveList<string> fixture = [];
@@ -98,7 +98,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add single complex item].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddSingleComplexItem()
     {
         ReactiveList<TestData> fixture = [];
@@ -111,7 +111,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add single item].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddSingleItem()
     {
         ReactiveList<string> fixture = [];
@@ -124,7 +124,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can clear and add item].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanClearAndAddItem()
     {
         ReactiveList<string> fixture = [];
@@ -158,7 +158,7 @@ public class ReactiveListAddTests
     /// Determines whether this instance [can observe add array of item asynchronous].
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task CanObserveAddArrayOfItemAsync()
     {
         ReactiveList<string> fixture = [];
@@ -181,7 +181,7 @@ public class ReactiveListAddTests
     /// Determines whether this instance [can observe add single item asynchronous].
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task CanObserveAddSingleItemAsync()
     {
         ReactiveList<string> fixture = [];
@@ -204,7 +204,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can replace all items].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanReplaceAllItems()
     {
         ReactiveList<string> fixture = [];
@@ -227,7 +227,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can replace all items many times].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanReplaceAllItemsManyTimes()
     {
         ReactiveList<string> fixture = [];
@@ -256,7 +256,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can replace all items with complex items].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanReplaceAllItemsWithComplexItems()
     {
         ReactiveList<TestData> fixture = [];
@@ -279,7 +279,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can replace all items with complex items and edit].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanReplaceAllItemsWithComplexItemsAndEdit()
     {
         ReactiveList<TestData> fixture = [];
@@ -308,7 +308,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can replace all items with complex items and edit and remove].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanReplaceAllItemsWithComplexItemsAndEditAndRemove()
     {
         ReactiveList<TestData> fixture = [];
@@ -342,7 +342,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can replace all items with complex items and edit and remove and add].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanReplaceAllItemsWithComplexItemsAndEditAndRemoveAndAdd()
     {
         ReactiveList<TestData> fixture = [];
@@ -387,7 +387,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can replace all items with complex items and edit and remove and add and clear].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanReplaceAllItemsWithComplexItemsAndEditAndRemoveAndAddAndClear()
     {
         ReactiveList<TestData> fixture = [];
@@ -431,7 +431,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add items and insert items].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddItemsAndInsertItems()
     {
         ReactiveList<string> fixture = [];
@@ -454,7 +454,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add items and insert items and remove at index].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddItemsAndInsertItemsAndRemoveAtIndex()
     {
         ReactiveList<string> fixture = [];
@@ -482,7 +482,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance can enumerate.
     /// </summary>
-    [Fact]
+    [Test]
     public void CanEnumerate()
     {
         ReactiveList<string> fixture = [];
@@ -498,7 +498,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can get an element at the index or return default].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanGetElementAtOrDefault()
     {
         ReactiveList<string> fixture = [];
@@ -513,7 +513,7 @@ public class ReactiveListAddTests
     /// <summary>
     /// Determines whether this instance [can add items to a list then add to fixture].
     /// </summary>
-    [Fact]
+    [Test]
     public void CanAddItemsToAListThenAddToFixture()
     {
         List<string> fixture = [];

--- a/src/ReactiveList.Test/ReactiveListConnectTests.cs
+++ b/src/ReactiveList.Test/ReactiveListConnectTests.cs
@@ -8,7 +8,7 @@ using CP.Reactive;
 using CP.Reactive.Collections;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -20,7 +20,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// Connect returns observable stream.
     /// </summary>
-    [Fact]
+    [Test]
     public void Connect_ReturnsObservableStream()
     {
         // Arrange
@@ -36,7 +36,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// Connect emits add changes when items are added.
     /// </summary>
-    [Fact]
+    [Test]
     public void Connect_EmitsAddChanges_WhenItemsAdded()
     {
         // Arrange
@@ -58,7 +58,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// Connect emits batch add changes when AddRange is called.
     /// </summary>
-    [Fact]
+    [Test]
     public void Connect_EmitsBatchAddChanges_WhenAddRangeCalled()
     {
         // Arrange
@@ -78,7 +78,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// Connect emits remove changes when items are removed.
     /// </summary>
-    [Fact]
+    [Test]
     public void Connect_EmitsRemoveChanges_WhenItemsRemoved()
     {
         // Arrange
@@ -101,7 +101,7 @@ public class ReactiveListConnectTests
     /// Connect emits clear changes when collection is cleared.
     /// Clear emits individual Remove changes for each cleared item (consistent with DynamicData behavior).
     /// </summary>
-    [Fact]
+    [Test]
     public void Connect_EmitsClearChanges_WhenCleared()
     {
         // Arrange
@@ -124,7 +124,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// Connect emits move changes when item is moved.
     /// </summary>
-    [Fact]
+    [Test]
     public void Connect_EmitsMoveChanges_WhenItemMoved()
     {
         // Arrange
@@ -148,7 +148,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// Connect emits update changes when item is updated.
     /// </summary>
-    [Fact]
+    [Test]
     public void Connect_EmitsUpdateChanges_WhenItemUpdated()
     {
         // Arrange
@@ -170,7 +170,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// ChangeSet correctly counts different change types.
     /// </summary>
-    [Fact]
+    [Test]
     public void ChangeSet_CorrectlyCounts_DifferentChangeTypes()
     {
         // Arrange
@@ -197,7 +197,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// ChangeSet can be enumerated.
     /// </summary>
-    [Fact]
+    [Test]
     public void ChangeSet_CanBeEnumerated()
     {
         // Arrange
@@ -222,7 +222,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// ChangeSet indexer returns correct change.
     /// </summary>
-    [Fact]
+    [Test]
     public void ChangeSet_Indexer_ReturnsCorrectChange()
     {
         // Arrange
@@ -243,7 +243,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// ChangeSet indexer throws on out of range.
     /// </summary>
-    [Fact]
+    [Test]
     public void ChangeSet_Indexer_ThrowsOnOutOfRange()
     {
         // Arrange
@@ -257,7 +257,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// Change factory methods create correct change types.
     /// </summary>
-    [Fact]
+    [Test]
     public void Change_FactoryMethods_CreateCorrectChangeTypes()
     {
         // Act
@@ -291,11 +291,11 @@ public class ReactiveListConnectTests
         refresh.CurrentIndex.Should().Be(2);
     }
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETFRAMEWORK
     /// <summary>
     /// ToArray returns snapshot of current items.
     /// </summary>
-    [Fact]
+    [Test]
     public void ToArray_ReturnsSnapshot()
     {
         // Arrange
@@ -311,7 +311,7 @@ public class ReactiveListConnectTests
     /// <summary>
     /// ToArray returns empty array for empty list.
     /// </summary>
-    [Fact]
+    [Test]
     public void ToArray_ReturnsEmptyArray_ForEmptyList()
     {
         // Arrange

--- a/src/ReactiveList.Test/ReactiveListCoverageTests.cs
+++ b/src/ReactiveList.Test/ReactiveListCoverageTests.cs
@@ -1,0 +1,341 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using CP.Reactive.Collections;
+using CP.Reactive.Core;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace ReactiveList.Test;
+
+/// <summary>
+/// Additional coverage tests for <see cref="ReactiveList{T}"/>.
+/// </summary>
+public class ReactiveListCoverageTests
+{
+    /// <summary>
+    /// Reactive observables and collection metadata should reflect list changes.
+    /// </summary>
+    [Test]
+    public void ObservablePropertiesAndMetadata_ShouldReflectChanges()
+    {
+        ReactiveList<string> fixture = [];
+        var changed = new List<string[]>();
+        var current = new List<string[]>();
+        var removed = new List<string[]>();
+
+        using var changedSubscription = fixture.Changed.Subscribe(items => changed.Add(items.ToArray()));
+        using var currentSubscription = fixture.CurrentItems.Subscribe(items => current.Add(items.ToArray()));
+        using var removedSubscription = fixture.Removed.Subscribe(items => removed.Add(items.ToArray()));
+
+        fixture.IsDisposed.Should().BeFalse();
+        fixture.IsFixedSize.Should().BeFalse();
+        fixture.IsReadOnly.Should().BeFalse();
+        fixture.IsSynchronized.Should().BeFalse();
+        fixture.SyncRoot.Should().BeSameAs(fixture);
+
+        fixture.Add("one");
+        fixture.Update("one", "uno");
+        fixture.Remove("uno");
+
+        changed.SelectMany(items => items).Should().Contain(["one", "uno"]);
+        current.Should().NotBeEmpty();
+        current[current.Count - 1].Should().BeEmpty();
+        removed.Should().ContainSingle()
+            .Which.Should().Equal("uno");
+    }
+
+    /// <summary>
+    /// Explicit non-generic collection APIs should validate and mutate consistently.
+    /// </summary>
+    [Test]
+    public void NonGenericCollectionMembers_ShouldValidateAndMutate()
+    {
+        ReactiveList<string> fixture = ["one", "two"];
+        var list = (IList)fixture;
+        var collection = (ICollection)fixture;
+
+        list[0].Should().Be("one");
+        list[0] = "zero";
+        fixture[0].Should().Be("zero");
+
+        list.Add("three").Should().Be(2);
+        list.Insert(1, "inserted");
+        list.Contains("two").Should().BeTrue();
+        list.Contains(42).Should().BeFalse();
+        list.IndexOf("three").Should().Be(3);
+        list.IndexOf(42).Should().Be(-1);
+        list.Remove("inserted");
+        list.Remove(42);
+
+        var objects = new object[fixture.Count];
+        collection.CopyTo(objects, 0);
+        objects.Should().Equal("zero", "two", "three");
+
+        var typed = new string[fixture.Count];
+        collection.CopyTo(typed, 0);
+        typed.Should().Equal("zero", "two", "three");
+
+        Action addWrongType = () => list.Add(42);
+        Action insertWrongType = () => list.Insert(0, 42);
+        Action copyNull = () => collection.CopyTo(null!, 0);
+        Action copyMultiDimensional = () => collection.CopyTo(Array.CreateInstance(typeof(string), 1, 1), 0);
+        Action copyNonZeroLowerBound = () => collection.CopyTo(Array.CreateInstance(typeof(string), [3], [1]), 0);
+        Action copyNegativeIndex = () => collection.CopyTo(new string[3], -1);
+        Action copyTooSmall = () => collection.CopyTo(new string[2], 0);
+        Action copyInvalidArrayType = () => ((ICollection)new ReactiveList<int>([1])).CopyTo(new string[1], 0);
+
+        addWrongType.Should().Throw<InvalidCastException>();
+        insertWrongType.Should().Throw<InvalidCastException>();
+        copyNull.Should().Throw<ArgumentNullException>()
+            .WithParameterName("array");
+        copyMultiDimensional.Should().Throw<ArgumentException>()
+            .WithParameterName("array");
+        copyNonZeroLowerBound.Should().Throw<ArgumentException>()
+            .WithParameterName("array");
+        copyNegativeIndex.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("index");
+        copyTooSmall.Should().Throw<ArgumentException>()
+            .WithParameterName("array");
+        copyInvalidArrayType.Should().Throw<ArgumentException>();
+
+        list.Clear();
+        fixture.Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Generic explicit members and empty batch branches should be no-ops.
+    /// </summary>
+    [Test]
+    public void GenericExplicitMembersAndEmptyBatches_ShouldBehaveConsistently()
+    {
+        ReactiveList<int> fixture = [1, 2, 3, 4];
+        var genericCollection = (ICollection<int>)fixture;
+        var genericList = (IList<int>)fixture;
+
+        genericList.IndexOf(3).Should().Be(2);
+        ((IList)fixture).IndexOf(null).Should().Be(-1);
+        ((IList)fixture).Contains(null).Should().BeFalse();
+
+        fixture.AddRange(Array.Empty<int>());
+        fixture.InsertRange(2, Array.Empty<int>());
+        fixture.Remove(Array.Empty<int>());
+        fixture.RemoveRange(0, 0);
+
+        fixture.Count.Should().Be(4);
+
+        genericList.RemoveAt(0);
+        ((IList)fixture).RemoveAt(0);
+        fixture.Should().Equal(3, 4);
+
+        genericCollection.Clear();
+        fixture.Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Reactive2DList guard branches should validate outer indexes and null row values.
+    /// </summary>
+    [Test]
+    public void Reactive2DList_Guards_ShouldValidateOuterIndexesAndNullRows()
+    {
+        Reactive2DList<string> grid = [["a"]];
+
+        Action addManyBadOuter = () => grid.AddToInner(10, new[] { "b" });
+        Action addSingleBadOuter = () => grid.AddToInner(-1, "b");
+        Action insertNullItem = () => grid.Insert(0, (string)null!);
+
+        addManyBadOuter.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("outerIndex");
+        addSingleBadOuter.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("outerIndex");
+        insertNullItem.Should().Throw<ArgumentNullException>()
+            .WithParameterName("item");
+    }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Span and memory helpers should copy snapshots and validate destination size.
+    /// </summary>
+    [Test]
+    public void SpanAndMemoryHelpers_ShouldCopySnapshotsAndValidateDestination()
+    {
+        ReactiveList<int> fixture = [1, 2, 3];
+
+        fixture.ToArray().Should().Equal(1, 2, 3);
+        fixture.AsSpan().ToArray().Should().Equal(1, 2, 3);
+        fixture.AsMemory().ToArray().Should().Equal(1, 2, 3);
+
+        var destination = new int[3];
+        fixture.CopyTo(destination.AsSpan());
+        destination.Should().Equal(1, 2, 3);
+
+        Action copyTooSmall = () => fixture.CopyTo(new int[2].AsSpan());
+        copyTooSmall.Should().Throw<ArgumentException>()
+            .WithParameterName("destination");
+
+        fixture.AddRange(ReadOnlySpan<int>.Empty);
+        fixture.Count.Should().Be(3);
+
+        int[] values = [4, 5];
+        fixture.AddRange(values.AsSpan());
+        fixture.Should().Equal(1, 2, 3, 4, 5);
+    }
+#endif
+
+#if NET6_0_OR_GREATER || NETFRAMEWORK
+    /// <summary>
+    /// ClearWithoutDeallocation should support silent and notifying branches.
+    /// </summary>
+    [Test]
+    public void ClearWithoutDeallocation_ShouldSupportSilentAndNotifyingBranches()
+    {
+        ReactiveList<int> fixture = [];
+        var propertyNames = new List<string?>();
+        fixture.PropertyChanged += (sender, args) => propertyNames.Add(args.PropertyName);
+
+        fixture.ClearWithoutDeallocation(notifyChange: false);
+        propertyNames.Should().BeEmpty();
+
+        fixture.ClearWithoutDeallocation();
+        propertyNames.Should().Equal(nameof(fixture.Count), "Item[]");
+
+        fixture.AddRange([1, 2, 3]);
+        propertyNames.Clear();
+        fixture.ClearWithoutDeallocation(notifyChange: false);
+
+        fixture.Count.Should().Be(0);
+        fixture.Items.Should().BeEmpty();
+        propertyNames.Should().BeEmpty();
+
+        fixture.AddRange([4, 5]);
+        fixture.ClearWithoutDeallocation();
+
+        fixture.Count.Should().Be(0);
+        fixture.ItemsRemoved.Should().Equal(4, 5);
+        fixture.ItemsChanged.Should().Equal(4, 5);
+    }
+#endif
+
+    /// <summary>
+    /// Removal APIs should validate ranges and report only removed items.
+    /// </summary>
+    [Test]
+    public void RemovalBranches_ShouldValidateRangesAndReportRemovedItems()
+    {
+        ReactiveList<int> fixture = [.. Enumerable.Range(0, 40)];
+        var removed = new List<int[]>();
+        using var subscription = fixture.Removed.Subscribe(items => removed.Add(items.ToArray()));
+
+        fixture.Remove([1, 100, 3]);
+
+        fixture.Count.Should().Be(38);
+        removed.Should().ContainSingle()
+            .Which.Should().Equal(1, 3);
+
+        Action removeManyNull = () => fixture.RemoveMany(null!);
+        Action removeAtInvalid = () => fixture.RemoveAt(-1);
+        Action removeRangeBadIndex = () => fixture.RemoveRange(-1, 1);
+        Action removeRangeBadCount = () => fixture.RemoveRange(0, fixture.Count + 1);
+
+        removeManyNull.Should().Throw<ArgumentNullException>()
+            .WithParameterName("predicate");
+        removeAtInvalid.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("index");
+        removeRangeBadIndex.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("index");
+        removeRangeBadCount.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("count");
+
+        fixture.RemoveRange(0, 2);
+        var removedCount = fixture.RemoveMany(_ => true);
+
+        removedCount.Should().Be(36);
+        fixture.Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// CollectionChanged should use specific actions for single changes and reset for batches.
+    /// </summary>
+    [Test]
+    public void CollectionChanged_ShouldUseSpecificActionsForSingleChangesAndResetForBatches()
+    {
+        ReactiveList<string> fixture = ["one", "two", "three"];
+        var events = new List<NotifyCollectionChangedEventArgs>();
+        fixture.CollectionChanged += (sender, args) => events.Add(args);
+
+        fixture.Add("four");
+        fixture.Remove("four");
+        fixture.Move(0, 1);
+        fixture.AddRange(["five", "six"]);
+
+        events.Select(args => args.Action).Should().Equal(
+            NotifyCollectionChangedAction.Add,
+            NotifyCollectionChangedAction.Remove,
+            NotifyCollectionChangedAction.Move,
+            NotifyCollectionChangedAction.Reset);
+        events[0].NewStartingIndex.Should().Be(3);
+        events[1].OldStartingIndex.Should().Be(3);
+        events[2].OldStartingIndex.Should().Be(0);
+        events[2].NewStartingIndex.Should().Be(1);
+    }
+
+    /// <summary>
+    /// ReplaceAll should emit old and new batches when either side is populated.
+    /// </summary>
+    [Test]
+    public void ReplaceAll_ShouldEmitOldAndNewBatchesWhenPresent()
+    {
+        ReactiveList<string> fixture = [];
+        var actions = new List<CacheAction>();
+        using var subscription = fixture.Stream.Subscribe(notification =>
+        {
+            actions.Add(notification.Action);
+            notification.Batch?.Dispose();
+        });
+
+        fixture.ReplaceAll(["one", "two"]);
+        fixture.ReplaceAll(Array.Empty<string>());
+
+        fixture.Count.Should().Be(0);
+        actions.Should().Equal(CacheAction.BatchAdded, CacheAction.BatchRemoved);
+    }
+
+    /// <summary>
+    /// Subscribe should delegate to CurrentItems and Dispose should release resources.
+    /// </summary>
+    [Test]
+    public void SubscribeAndDispose_ShouldUseCurrentItemsAndReleaseResources()
+    {
+        ReactiveList<int> fixture = [];
+        var observer = new RecordingObserver<int>();
+        using var subscription = fixture.Subscribe(observer);
+
+        fixture.Add(10);
+        observer.Snapshots.Should().HaveCountGreaterThanOrEqualTo(2);
+        observer.Snapshots[observer.Snapshots.Count - 1].Should().Equal(10);
+
+        fixture.Dispose();
+
+        fixture.IsDisposed.Should().BeTrue();
+    }
+
+    private sealed class RecordingObserver<T> : IObserver<IEnumerable<T>>
+    {
+        public List<T[]> Snapshots { get; } = [];
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(IEnumerable<T> value) => Snapshots.Add(value.ToArray());
+    }
+}

--- a/src/ReactiveList.Test/ReactiveListEditTests.cs
+++ b/src/ReactiveList.Test/ReactiveListEditTests.cs
@@ -4,7 +4,7 @@
 using System;
 using CP.Reactive.Collections;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -16,7 +16,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow batch add operations.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowBatchAddOperations()
     {
         ReactiveList<string> fixture = [];
@@ -37,7 +37,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow batch remove operations.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowBatchRemoveOperations()
     {
         ReactiveList<string> fixture = ["one", "two", "three", "four"];
@@ -56,7 +56,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow mixed operations.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowMixedOperations()
     {
         ReactiveList<string> fixture = ["one", "two"];
@@ -78,7 +78,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow clear and repopulate.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowClearAndRepopulate()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -98,7 +98,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should throw when action is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldThrowWhenActionIsNull()
     {
         ReactiveList<string> fixture = [];
@@ -112,7 +112,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should raise property changed once for count.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldRaisePropertyChanged()
     {
         ReactiveList<string> fixture = [];
@@ -145,7 +145,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow insert at index.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowInsertAtIndex()
     {
         ReactiveList<string> fixture = ["one", "three"];
@@ -161,7 +161,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow remove at index.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowRemoveAtIndex()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -176,7 +176,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow add range.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowAddRange()
     {
         ReactiveList<string> fixture = ["one"];
@@ -193,7 +193,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow replace operation.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowReplaceOperation()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -214,7 +214,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should work with complex types.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldWorkWithComplexTypes()
     {
         ReactiveList<TestData> fixture = [];
@@ -233,7 +233,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should handle empty action gracefully.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldHandleEmptyActionGracefully()
     {
         ReactiveList<string> fixture = ["one", "two"];
@@ -248,7 +248,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow move operation.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowMoveOperation()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -264,7 +264,7 @@ public class ReactiveListEditTests
     /// <summary>
     /// Edit should allow multiple operations in sequence.
     /// </summary>
-    [Fact]
+    [Test]
     public void Edit_ShouldAllowMultipleOperationsInSequence()
     {
         ReactiveList<int> fixture = [];

--- a/src/ReactiveList.Test/ReactiveListExtensionsAdditionalTests.cs
+++ b/src/ReactiveList.Test/ReactiveListExtensionsAdditionalTests.cs
@@ -13,7 +13,7 @@ using CP.Reactive;
 using CP.Reactive.Collections;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Tests;
 
@@ -26,7 +26,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that OnUpdate returns previous and current values when items are updated.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnUpdate_ReturnsPreviousAndCurrentValues()
     {
         // Arrange
@@ -50,7 +50,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that OnUpdate does not emit for add operations.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnUpdate_DoesNotEmitForAddOperations()
     {
         // Arrange
@@ -73,7 +73,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that OnUpdate handles multiple sequential updates with previous values.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnUpdate_HandlesMultipleSequentialUpdates()
     {
         // Arrange
@@ -103,7 +103,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that OnMove returns item and indices when items are moved.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnMove_ReturnsItemAndIndices()
     {
         // Arrange
@@ -128,7 +128,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that OnMove does not emit for add or remove operations.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnMove_DoesNotEmitForAddRemove()
     {
         // Arrange
@@ -151,7 +151,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that OnMove handles multiple move operations.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnMove_HandlesMultipleMoves()
     {
         // Arrange
@@ -174,7 +174,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that FilterDynamic filters items based on dynamic predicate.
     /// </summary>
-    [Fact]
+    [Test]
     public void FilterDynamic_FiltersBasedOnDynamicPredicate()
     {
         // Arrange
@@ -213,7 +213,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that FilterDynamic always passes removed items.
     /// </summary>
-    [Fact]
+    [Test]
     public void FilterDynamic_AlwaysPassesRemovedItems()
     {
         // Arrange
@@ -243,7 +243,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that FilterDynamic passes Cleared notifications.
     /// </summary>
-    [Fact]
+    [Test]
     public void FilterDynamic_PassesClearedNotifications()
     {
         // Arrange
@@ -273,7 +273,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// Tests that CreateView without filter contains all items.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task CreateView_WithoutFilter_ContainsAllItems()
     {
         // Arrange
@@ -293,7 +293,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// Tests that CreateView without filter updates when source changes.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task CreateView_WithoutFilter_UpdatesOnSourceChange()
     {
         // Arrange
@@ -311,13 +311,13 @@ public class ReactiveListExtensionsAdditionalTests
         view.Should().BeEquivalentTo(new[] { 1, 2, 3, 4 });
     }
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
     /// <summary>
     /// Tests that CreateView with query observable filters based on query.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task CreateView_WithQueryObservable_FiltersBasedOnQuery()
     {
         // Arrange
@@ -355,7 +355,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// Tests that CreateView with query observable updates when source changes.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task CreateView_WithQueryObservable_UpdatesWhenSourceChanges()
     {
         // Arrange
@@ -392,7 +392,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that GroupByChanges groups items by key selector.
     /// </summary>
-    [Fact]
+    [Test]
     public void GroupByChanges_GroupsItemsByKeySelector()
     {
         // Arrange
@@ -427,7 +427,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that GroupByChanges handles string keys.
     /// </summary>
-    [Fact]
+    [Test]
     public void GroupByChanges_HandlesStringKeys()
     {
         // Arrange
@@ -461,7 +461,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that GroupingByChanges creates proper groupings.
     /// </summary>
-    [Fact]
+    [Test]
     public void GroupingByChanges_CreatesProperGroupings()
     {
         // Arrange
@@ -482,7 +482,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that GroupingByChanges handles batch operations.
     /// </summary>
-    [Fact]
+    [Test]
     public void GroupingByChanges_HandlesBatchAdd()
     {
         // Arrange
@@ -507,7 +507,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that AutoRefresh emits refresh when property changes.
     /// </summary>
-    [Fact]
+    [Test]
     public void AutoRefresh_EmitsRefreshWhenPropertyChanges()
     {
         // Arrange
@@ -532,7 +532,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that AutoRefresh does not emit for unrelated property changes.
     /// </summary>
-    [Fact]
+    [Test]
     public void AutoRefresh_DoesNotEmitForUnrelatedPropertyChanges()
     {
         // Arrange
@@ -557,7 +557,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that AutoRefresh without property name watches all property changes.
     /// </summary>
-    [Fact]
+    [Test]
     public void AutoRefresh_WithoutPropertyName_WatchesAllProperties()
     {
         // Arrange
@@ -583,7 +583,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that Connect returns observable of change sets.
     /// </summary>
-    [Fact]
+    [Test]
     public void Connect_ReturnsObservableOfChangeSets()
     {
         // Arrange
@@ -606,7 +606,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that Connect throws for null source.
     /// </summary>
-    [Fact]
+    [Test]
     public void Connect_ThrowsForNullSource()
     {
         // Arrange
@@ -620,7 +620,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that WhereItems filters notifications by predicate.
     /// </summary>
-    [Fact]
+    [Test]
     public void WhereItems_FiltersNotificationsByPredicate()
     {
         // Arrange
@@ -650,7 +650,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that WhereItems passes Cleared notifications.
     /// </summary>
-    [Fact]
+    [Test]
     public void WhereItems_PassesClearedNotifications()
     {
         // Arrange
@@ -678,7 +678,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that WhereItems passes BatchOperation notifications.
     /// </summary>
-    [Fact]
+    [Test]
     public void WhereItems_PassesBatchOperations()
     {
         // Arrange
@@ -706,7 +706,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that WhereItems correctly filters value types including zero.
     /// </summary>
-    [Fact]
+    [Test]
     public void WhereItems_HandlesValueTypesIncludingZero()
     {
         // Arrange
@@ -737,7 +737,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that SortBy sorts change sets by key selector.
     /// </summary>
-    [Fact]
+    [Test]
     public void SortBy_SortsChangeSetsByKeySelector()
     {
         // Arrange
@@ -765,7 +765,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that SortBy handles string sorting.
     /// </summary>
-    [Fact]
+    [Test]
     public void SortBy_HandlesStringSorting()
     {
         // Arrange
@@ -793,7 +793,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that SelectChanges transforms to different type maintaining change metadata.
     /// </summary>
-    [Fact]
+    [Test]
     public void SelectChanges_TransformsToDifferentType()
     {
         // Arrange
@@ -817,7 +817,7 @@ public class ReactiveListExtensionsAdditionalTests
     /// <summary>
     /// Tests that SelectChanges preserves change reason.
     /// </summary>
-    [Fact]
+    [Test]
     public void SelectChanges_PreservesChangeReason()
     {
         // Arrange

--- a/src/ReactiveList.Test/ReactiveListExtensionsTests.cs
+++ b/src/ReactiveList.Test/ReactiveListExtensionsTests.cs
@@ -11,7 +11,7 @@ using CP.Reactive;
 using CP.Reactive.Collections;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Tests;
 
@@ -23,7 +23,7 @@ public class ReactiveListExtensionsTests
     /// <summary>
     /// Tests that WhereChanges filters changes by predicate.
     /// </summary>
-    [Fact]
+    [Test]
     public void WhereChanges_FiltersChangesByPredicate()
     {
         // Arrange
@@ -53,7 +53,7 @@ public class ReactiveListExtensionsTests
     /// <summary>
     /// Tests that WhereReason filters by specific change reason.
     /// </summary>
-    [Fact]
+    [Test]
     public void WhereReason_FiltersAddOnly()
     {
         // Arrange
@@ -76,7 +76,7 @@ public class ReactiveListExtensionsTests
     /// <summary>
     /// Tests that OnAdd returns only added items.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnAdd_ReturnsAddedItems()
     {
         // Arrange
@@ -99,7 +99,7 @@ public class ReactiveListExtensionsTests
     /// <summary>
     /// Tests that OnRemove returns only removed items.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnRemove_ReturnsRemovedItems()
     {
         // Arrange
@@ -122,7 +122,7 @@ public class ReactiveListExtensionsTests
     /// <summary>
     /// Tests that SelectChanges transforms items correctly using change selector.
     /// </summary>
-    [Fact]
+    [Test]
     public void SelectChanges_TransformsItems()
     {
         // Arrange
@@ -143,12 +143,12 @@ public class ReactiveListExtensionsTests
         transformedItems.Should().BeEquivalentTo(new[] { "Item_1", "Item_2", "Item_3" });
     }
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETFRAMEWORK
     /// <summary>
     /// Tests that CreateView creates a filtered view.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task CreateView_CreatesFilteredView()
     {
         // Arrange
@@ -170,7 +170,7 @@ public class ReactiveListExtensionsTests
     /// Tests that CreateView updates when source changes.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task CreateView_UpdatesOnSourceChange()
     {
         // Arrange
@@ -192,7 +192,7 @@ public class ReactiveListExtensionsTests
     /// Tests that DynamicFilteredView updates when filter changes.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task DynamicCreateView_UpdatesOnFilterChange()
     {
         // Arrange
@@ -218,7 +218,7 @@ public class ReactiveListExtensionsTests
     /// Tests that SortBy creates a sorted view.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task SortBy_CreatesSortedView()
     {
         // Arrange
@@ -237,7 +237,7 @@ public class ReactiveListExtensionsTests
     /// Tests that SortBy with key selector creates a sorted view.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task SortBy_WithKeySelector_CreatesSortedView()
     {
         // Arrange
@@ -257,7 +257,7 @@ public class ReactiveListExtensionsTests
     /// Tests that GroupBy creates a grouped view.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task GroupBy_CreatesGroupedView()
     {
         // Arrange
@@ -280,7 +280,7 @@ public class ReactiveListExtensionsTests
     /// Tests that GroupBy updates when items are added.
     /// </summary>
     /// <returns>A task representing the async test.</returns>
-    [Fact]
+    [Test]
     public async Task GroupBy_UpdatesOnAdd()
     {
         // Arrange
@@ -301,7 +301,7 @@ public class ReactiveListExtensionsTests
     /// <summary>
     /// Tests that AddRange with ReadOnlySpan works correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void AddRange_WithSpan_AddsItems()
     {
         // Arrange
@@ -319,7 +319,7 @@ public class ReactiveListExtensionsTests
     /// <summary>
     /// Tests that CopyTo with Span works correctly.
     /// </summary>
-    [Fact]
+    [Test]
     public void CopyTo_WithSpan_CopiesItems()
     {
         // Arrange
@@ -337,7 +337,7 @@ public class ReactiveListExtensionsTests
     /// <summary>
     /// Tests that AsSpan returns correct data.
     /// </summary>
-    [Fact]
+    [Test]
     public void AsSpan_ReturnsItems()
     {
         // Arrange
@@ -357,7 +357,7 @@ public class ReactiveListExtensionsTests
     /// <summary>
     /// Tests that AsMemory returns correct data.
     /// </summary>
-    [Fact]
+    [Test]
     public void AsMemory_ReturnsItems()
     {
         // Arrange

--- a/src/ReactiveList.Test/ReactiveListMoveTests.cs
+++ b/src/ReactiveList.Test/ReactiveListMoveTests.cs
@@ -4,7 +4,7 @@
 using System;
 using CP.Reactive.Collections;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -16,7 +16,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should reorder item forward in list.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldReorderItemForwardInList()
     {
         ReactiveList<string> fixture = ["one", "two", "three", "four"];
@@ -33,7 +33,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should reorder item backward in list.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldReorderItemBackwardInList()
     {
         ReactiveList<string> fixture = ["one", "two", "three", "four"];
@@ -50,7 +50,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should handle moving to first position.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldHandleMovingToFirstPosition()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -66,7 +66,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should handle moving to last position.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldHandleMovingToLastPosition()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -82,7 +82,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should do nothing when same index.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldDoNothingWhenSameIndex()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -98,7 +98,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should throw when old index is negative.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldThrowWhenOldIndexIsNegative()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -112,7 +112,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should throw when old index exceeds count.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldThrowWhenOldIndexExceedsCount()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -126,7 +126,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should throw when new index is negative.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldThrowWhenNewIndexIsNegative()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -140,7 +140,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should throw when new index exceeds count.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldThrowWhenNewIndexExceedsCount()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -154,7 +154,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should raise property changed for item array.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldRaisePropertyChangedForItemArray()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -169,7 +169,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should work with complex types.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldWorkWithComplexTypes()
     {
         ReactiveList<TestData> fixture =
@@ -190,7 +190,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should handle adjacent positions forward.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldHandleAdjacentPositionsForward()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -206,7 +206,7 @@ public class ReactiveListMoveTests
     /// <summary>
     /// Move should handle adjacent positions backward.
     /// </summary>
-    [Fact]
+    [Test]
     public void Move_ShouldHandleAdjacentPositionsBackward()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];

--- a/src/ReactiveList.Test/ReactiveListRemoveTests.cs
+++ b/src/ReactiveList.Test/ReactiveListRemoveTests.cs
@@ -6,7 +6,7 @@ using CP.Reactive;
 using CP.Reactive.Collections;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -18,7 +18,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// Remove should remove existing item for string type.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldRemoveExistingItem_String()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -35,7 +35,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// Remove should return false for non-existing item for string type.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldReturnFalseForNonExistingItem_String()
     {
         ReactiveList<string> fixture = ["one", "two"];
@@ -49,7 +49,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// Remove should raise property changed for string type.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldRaisePropertyChanged_String()
     {
         ReactiveList<string> fixture = ["one", "two"];
@@ -77,7 +77,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// Remove should remove existing item for int type.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldRemoveExistingItem_Int()
     {
         ReactiveList<int> fixture = [1, 2, 3];
@@ -94,7 +94,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// Remove should return false for non-existing item for int type.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldReturnFalseForNonExistingItem_Int()
     {
         ReactiveList<int> fixture = [1, 2];
@@ -108,7 +108,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// Remove should raise property changed for int type.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldRaisePropertyChanged_Int()
     {
         ReactiveList<int> fixture = [1, 2];
@@ -136,7 +136,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// Remove should remove existing item for TestData type.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldRemoveExistingItem_TestData()
     {
         ReactiveList<TestData> fixture = [new("Alice", 25), new("Bob", 30), new("Charlie", 35)];
@@ -153,7 +153,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// Remove should return false for non-existing item for TestData type.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldReturnFalseForNonExistingItem_TestData()
     {
         ReactiveList<TestData> fixture = [new("Alice", 25), new("Bob", 30)];
@@ -167,7 +167,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// Remove should raise property changed for TestData type.
     /// </summary>
-    [Fact]
+    [Test]
     public void Remove_ShouldRaisePropertyChanged_TestData()
     {
         ReactiveList<TestData> fixture = [new("Alice", 25), new("Bob", 30)];
@@ -196,7 +196,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveAt should remove item at index for string type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_ShouldRemoveItemAtIndex_String()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -211,7 +211,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveAt should throw for invalid index for string type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_ShouldThrowForInvalidIndex_String()
     {
         ReactiveList<string> fixture = ["one", "two"];
@@ -224,7 +224,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveAt should raise property changed for string type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_ShouldRaisePropertyChanged_String()
     {
         ReactiveList<string> fixture = ["one", "two"];
@@ -252,7 +252,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveAt should remove item at index for int type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_ShouldRemoveItemAtIndex_Int()
     {
         ReactiveList<int> fixture = [1, 2, 3];
@@ -267,7 +267,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveAt should throw for invalid index for int type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_ShouldThrowForInvalidIndex_Int()
     {
         ReactiveList<int> fixture = [1, 2];
@@ -280,7 +280,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveAt should raise property changed for int type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_ShouldRaisePropertyChanged_Int()
     {
         ReactiveList<int> fixture = [1, 2];
@@ -308,7 +308,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveAt should remove item at index for TestData type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_ShouldRemoveItemAtIndex_TestData()
     {
         ReactiveList<TestData> fixture = [new("Alice", 25), new("Bob", 30), new("Charlie", 35)];
@@ -323,7 +323,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveAt should throw for invalid index for TestData type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_ShouldThrowForInvalidIndex_TestData()
     {
         ReactiveList<TestData> fixture = [new("Alice", 25), new("Bob", 30)];
@@ -336,7 +336,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveAt should raise property changed for TestData type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveAt_ShouldRaisePropertyChanged_TestData()
     {
         ReactiveList<TestData> fixture = [new("Alice", 25), new("Bob", 30)];
@@ -364,7 +364,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveMany should remove items matching predicate for string type.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveMany_ShouldRemoveMatchingItems_String()
     {
         ReactiveList<string> fixture = ["apple", "banana", "apricot", "cherry", "avocado"];
@@ -383,7 +383,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveMany should return zero when no items match predicate.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveMany_ShouldReturnZeroWhenNoMatch()
     {
         ReactiveList<string> fixture = ["one", "two", "three"];
@@ -397,7 +397,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveMany should throw ArgumentNullException for null predicate.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveMany_ShouldThrowForNullPredicate()
     {
         ReactiveList<string> fixture = ["one", "two"];
@@ -410,7 +410,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveMany should raise property changed events.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveMany_ShouldRaisePropertyChanged()
     {
         ReactiveList<int> fixture = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -433,7 +433,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveMany should emit change notification via Connect.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveMany_ShouldEmitChangeNotification()
     {
         using var fixture = new ReactiveList<int>([1, 2, 3, 4, 5]);
@@ -450,7 +450,7 @@ public class ReactiveListRemoveTests
     /// <summary>
     /// RemoveMany should work with complex types.
     /// </summary>
-    [Fact]
+    [Test]
     public void RemoveMany_ShouldWorkWithComplexTypes()
     {
         ReactiveList<TestData> fixture =

--- a/src/ReactiveList.Test/ReactiveListSerializationTests.cs
+++ b/src/ReactiveList.Test/ReactiveListSerializationTests.cs
@@ -10,7 +10,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using CP.Reactive;
 using CP.Reactive.Collections;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -23,7 +23,7 @@ public class ReactiveListSerializationTests
     /// <summary>
     /// ReactiveList should be serializable.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReactiveList_ShouldBeSerializable()
     {
         var list = new ReactiveList<string>();
@@ -46,7 +46,7 @@ public class ReactiveListSerializationTests
     /// <summary>
     /// Deserialized ReactiveList should work normally.
     /// </summary>
-    [Fact]
+    [Test]
     public void DeserializedReactiveList_ShouldWorkNormally()
     {
         var list = new ReactiveList<int>();
@@ -76,7 +76,7 @@ public class ReactiveListSerializationTests
     /// <summary>
     /// Deserialized ReactiveList should support remove operations.
     /// </summary>
-    [Fact]
+    [Test]
     public void DeserializedReactiveList_ShouldSupportRemoveOperations()
     {
         var list = new ReactiveList<string>();
@@ -96,7 +96,7 @@ public class ReactiveListSerializationTests
     /// <summary>
     /// Deserialized ReactiveList should support clear operations.
     /// </summary>
-    [Fact]
+    [Test]
     public void DeserializedReactiveList_ShouldSupportClearOperations()
     {
         var list = new ReactiveList<int>();
@@ -116,7 +116,7 @@ public class ReactiveListSerializationTests
     /// <summary>
     /// Empty ReactiveList should be serializable.
     /// </summary>
-    [Fact]
+    [Test]
     public void EmptyReactiveList_ShouldBeSerializable()
     {
         var list = new ReactiveList<string>();
@@ -134,7 +134,7 @@ public class ReactiveListSerializationTests
     /// <summary>
     /// ReactiveList with complex types should be serializable.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReactiveListWithComplexTypes_ShouldBeSerializable()
     {
         var list = new ReactiveList<TestData>();

--- a/src/ReactiveList.Test/ReactiveListVersionTests.cs
+++ b/src/ReactiveList.Test/ReactiveListVersionTests.cs
@@ -6,7 +6,7 @@ using CP.Reactive;
 using CP.Reactive.Collections;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -18,7 +18,7 @@ public class ReactiveListVersionTests
     /// <summary>
     /// Tests that Version increments when adding an item.
     /// </summary>
-    [Fact]
+    [Test]
     public void Version_IncrementsOnAdd()
     {
         // Arrange
@@ -35,7 +35,7 @@ public class ReactiveListVersionTests
     /// <summary>
     /// Tests that Version increments when adding a range.
     /// </summary>
-    [Fact]
+    [Test]
     public void Version_IncrementsOnAddRange()
     {
         // Arrange
@@ -52,7 +52,7 @@ public class ReactiveListVersionTests
     /// <summary>
     /// Tests that Version increments when removing an item.
     /// </summary>
-    [Fact]
+    [Test]
     public void Version_IncrementsOnRemove()
     {
         // Arrange
@@ -69,7 +69,7 @@ public class ReactiveListVersionTests
     /// <summary>
     /// Tests that Version increments when clearing.
     /// </summary>
-    [Fact]
+    [Test]
     public void Version_IncrementsOnClear()
     {
         // Arrange
@@ -86,7 +86,7 @@ public class ReactiveListVersionTests
     /// <summary>
     /// Tests that Version increments when updating.
     /// </summary>
-    [Fact]
+    [Test]
     public void Version_IncrementsOnUpdate()
     {
         // Arrange
@@ -103,7 +103,7 @@ public class ReactiveListVersionTests
     /// <summary>
     /// Tests that Version increments when moving.
     /// </summary>
-    [Fact]
+    [Test]
     public void Version_IncrementsOnMove()
     {
         // Arrange
@@ -117,11 +117,11 @@ public class ReactiveListVersionTests
         list.Version.Should().Be(initialVersion + 1);
     }
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETFRAMEWORK
     /// <summary>
     /// Tests that ClearWithoutDeallocation clears items but preserves capacity.
     /// </summary>
-    [Fact]
+    [Test]
     public void ClearWithoutDeallocation_ClearsItemsPreservesCapacity()
     {
         // Arrange
@@ -140,7 +140,7 @@ public class ReactiveListVersionTests
     /// <summary>
     /// Tests that ClearWithoutDeallocation emits change notification.
     /// </summary>
-    [Fact]
+    [Test]
     public void ClearWithoutDeallocation_EmitsChangeNotification()
     {
         // Arrange
@@ -161,7 +161,7 @@ public class ReactiveListVersionTests
     /// <summary>
     /// Tests that ClearWithoutDeallocation with notifyChange=false does not emit.
     /// </summary>
-    [Fact]
+    [Test]
     public void ClearWithoutDeallocation_WithNotifyFalse_DoesNotEmit()
     {
         // Arrange
@@ -184,7 +184,7 @@ public class ReactiveListVersionTests
     /// <summary>
     /// Tests that ClearWithoutDeallocation increments version.
     /// </summary>
-    [Fact]
+    [Test]
     public void ClearWithoutDeallocation_IncrementsVersion()
     {
         // Arrange

--- a/src/ReactiveList.Test/ReactiveViewTests.cs
+++ b/src/ReactiveList.Test/ReactiveViewTests.cs
@@ -11,7 +11,7 @@ using CP.Reactive.Collections;
 using CP.Reactive.Core;
 using CP.Reactive.Views;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -23,7 +23,7 @@ public class ReactiveViewTests
     /// <summary>
     /// Constructor should throw when stream is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithNullStream_ShouldThrow()
     {
         var act = () => new ReactiveView<string>(
@@ -40,7 +40,7 @@ public class ReactiveViewTests
     /// <summary>
     /// Constructor should throw when filter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithNullFilter_ShouldThrow()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -59,7 +59,7 @@ public class ReactiveViewTests
     /// <summary>
     /// Constructor should load initial snapshot.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithSnapshot_ShouldLoadItems()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -78,7 +78,7 @@ public class ReactiveViewTests
     /// <summary>
     /// Constructor should filter snapshot items.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithFilter_ShouldFilterSnapshot()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -97,7 +97,7 @@ public class ReactiveViewTests
     /// <summary>
     /// Constructor with null snapshot should not throw.
     /// </summary>
-    [Fact]
+    [Test]
     public void Constructor_WithNullSnapshot_ShouldNotThrow()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -118,7 +118,7 @@ public class ReactiveViewTests
     /// <summary>
     /// Items property should be read-only.
     /// </summary>
-    [Fact]
+    [Test]
     public void Items_ShouldBeReadOnly()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -137,7 +137,7 @@ public class ReactiveViewTests
     /// Added notification should add item to view.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task AddedNotification_ShouldAddItemToView()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -160,7 +160,7 @@ public class ReactiveViewTests
     /// Added notification with filter should only add matching items.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task AddedNotification_WithFilter_ShouldOnlyAddMatchingItems()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -184,7 +184,7 @@ public class ReactiveViewTests
     /// Removed notification should remove item from view.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task RemovedNotification_ShouldRemoveItemFromView()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -207,7 +207,7 @@ public class ReactiveViewTests
     /// Cleared notification should clear view.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task ClearedNotification_ShouldClearView()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -230,7 +230,7 @@ public class ReactiveViewTests
     /// BatchOperation notification should add batch items.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task BatchOperationNotification_ShouldAddBatchItems()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -259,7 +259,7 @@ public class ReactiveViewTests
     /// BatchOperation with filter should only add matching items.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task BatchOperationNotification_WithFilter_ShouldFilterItems()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -287,7 +287,7 @@ public class ReactiveViewTests
     /// <summary>
     /// ToProperty should set property.
     /// </summary>
-    [Fact]
+    [Test]
     public void ToProperty_ShouldSetProperty()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -309,7 +309,7 @@ public class ReactiveViewTests
     /// <summary>
     /// ToProperty should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void ToProperty_WithNullSetter_ShouldThrow()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -330,7 +330,7 @@ public class ReactiveViewTests
     /// <summary>
     /// Dispose should clean up subscription.
     /// </summary>
-    [Fact]
+    [Test]
     public void Dispose_ShouldCleanUpSubscription()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -350,7 +350,7 @@ public class ReactiveViewTests
     /// <summary>
     /// Multiple dispose should be safe.
     /// </summary>
-    [Fact]
+    [Test]
     public void Dispose_MultipleCalls_ShouldBeSafe()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -372,7 +372,7 @@ public class ReactiveViewTests
     /// PropertyChanged should fire when items updated.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task PropertyChanged_ShouldFireWhenItemsUpdated()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -404,7 +404,7 @@ public class ReactiveViewTests
     /// Added notification with null item should not add anything.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task AddedNotification_WithNullItem_ShouldNotAdd()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -427,7 +427,7 @@ public class ReactiveViewTests
     /// Removed notification with null item should not throw.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task RemovedNotification_WithNullItem_ShouldNotThrow()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -452,7 +452,7 @@ public class ReactiveViewTests
     /// Batch notification with null batch should not throw.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task BatchNotification_WithNullBatch_ShouldNotThrow()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -477,7 +477,7 @@ public class ReactiveViewTests
     /// View should buffer multiple notifications.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task View_ShouldBufferMultipleNotifications()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -503,7 +503,7 @@ public class ReactiveViewTests
     /// Updated action should not add or remove.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task UpdatedAction_ShouldNotChangeItems()
     {
         var subject = new Subject<CacheNotify<string>>();

--- a/src/ReactiveList.Test/SecondaryIndexTests.cs
+++ b/src/ReactiveList.Test/SecondaryIndexTests.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CP.Reactive.Core;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -20,7 +20,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// OnAdded should add item to index.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnAdded_ShouldAddItemToIndex()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -34,7 +34,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// OnAdded should add multiple items with same key.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnAdded_WithSameKey_ShouldAddMultipleItems()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -53,7 +53,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// OnAdded should handle items with different keys.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnAdded_WithDifferentKeys_ShouldIndexSeparately()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -70,7 +70,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// OnRemoved should remove item from index.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnRemoved_ShouldRemoveItemFromIndex()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -85,7 +85,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// OnRemoved should only remove specified item.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnRemoved_ShouldOnlyRemoveSpecifiedItem()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -103,7 +103,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// OnRemoved should handle non-existing item gracefully.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnRemoved_WithNonExistingItem_ShouldNotThrow()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -117,7 +117,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// OnUpdated should update index with new key.
     /// </summary>
-    [Fact]
+    [Test]
     public void OnUpdated_ShouldUpdateIndex()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -134,7 +134,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// Lookup should return empty for non-existing key.
     /// </summary>
-    [Fact]
+    [Test]
     public void Lookup_WithNonExistingKey_ShouldReturnEmpty()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -147,7 +147,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// Clear should remove all items.
     /// </summary>
-    [Fact]
+    [Test]
     public void Clear_ShouldRemoveAllItems()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -165,7 +165,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// Index should handle integer keys.
     /// </summary>
-    [Fact]
+    [Test]
     public void Index_WithIntegerKey_ShouldWork()
     {
         var index = new SecondaryIndex<Person, int>(p => p.Id);
@@ -179,7 +179,7 @@ public class SecondaryIndexTests
     /// <summary>
     /// Index should distribute items across shards.
     /// </summary>
-    [Fact]
+    [Test]
     public void Index_ShouldDistributeAcrossShards()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -201,7 +201,7 @@ public class SecondaryIndexTests
     /// Index should be thread-safe for concurrent adds.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task Index_ShouldBeThreadSafeForConcurrentAdds()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);
@@ -222,7 +222,7 @@ public class SecondaryIndexTests
     /// Index should be thread-safe for concurrent removes.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-    [Fact]
+    [Test]
     public async Task Index_ShouldBeThreadSafeForConcurrentRemoves()
     {
         var index = new SecondaryIndex<Person, string>(p => p.Department);

--- a/src/ReactiveList.Test/TUnitAssemblyInfo.cs
+++ b/src/ReactiveList.Test/TUnitAssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using TUnit.Core;
+
+[assembly: NotInParallel]

--- a/src/ReactiveList.Test/ViewCoverageTests.cs
+++ b/src/ReactiveList.Test/ViewCoverageTests.cs
@@ -1,0 +1,532 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using CP.Reactive.Collections;
+using CP.Reactive.Core;
+using CP.Reactive.Views;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace ReactiveList.Tests;
+
+/// <summary>
+/// Coverage tests for reactive view implementations.
+/// </summary>
+public class ViewCoverageTests
+{
+    /// <summary>
+    /// Filtered views should track update transitions and refreshes.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task FilteredReactiveView_UpdateTransitions_ShouldAddRemoveReplaceAndRefresh()
+    {
+        using var list = new ReactiveList<int>();
+        list.AddRange(new[] { 2, 3, 4 });
+
+        using var view = new FilteredReactiveView<int>(
+            list,
+            static item => item % 2 == 0,
+            ImmediateScheduler.Instance,
+            TimeSpan.Zero);
+
+        view.Items.Should().Equal(2, 4);
+        view[0].Should().Be(2);
+
+        list.Update(2, 5);
+        await WaitForPipeline();
+        view.Items.Should().Equal(4);
+
+        list.Update(3, 6);
+        await WaitForPipeline();
+        view.Items.Should().Equal(4, 6);
+
+        list.Update(4, 8);
+        await WaitForPipeline();
+        view.Items.Should().Equal(8, 6);
+
+        list.Move(2, 0);
+        await WaitForPipeline();
+        view.Items.Should().Equal(8, 6);
+
+        view.Refresh();
+        view.ToArray().Should().Equal(8, 6);
+
+        list.Remove(6);
+        await WaitForPipeline();
+        view.Items.Should().Equal(8);
+
+        list.Clear();
+        await WaitForPipeline();
+        view.Items.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Sorted views should maintain comparer order through source changes.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task SortedReactiveView_Changes_ShouldKeepItemsSorted()
+    {
+        using var list = new ReactiveList<int>();
+        list.AddRange(new[] { 3, 1 });
+
+        using var view = new SortedReactiveView<int>(
+            list,
+            Comparer<int>.Default,
+            ImmediateScheduler.Instance,
+            TimeSpan.Zero);
+
+        view.Items.Should().Equal(1, 3);
+        view[1].Should().Be(3);
+
+        list.Add(2);
+        await WaitForPipeline();
+        view.Items.Should().Equal(1, 2, 3);
+
+        list.Update(3, 0);
+        await WaitForPipeline();
+        view.Items.Should().Equal(0, 1, 2);
+
+        list.Move(0, 2);
+        await WaitForPipeline();
+        view.Items.Should().Equal(0, 1, 2);
+
+        list.Remove(1);
+        await WaitForPipeline();
+        view.Items.Should().Equal(0, 2);
+
+        view.Refresh();
+        view.Items.Should().Equal(0, 2);
+    }
+
+    /// <summary>
+    /// Grouped views should expose dictionary members and update group membership.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task GroupedReactiveView_DictionarySurfaceAndUpdates_ShouldTrackGroups()
+    {
+        using var list = new ReactiveList<ViewItem>();
+        var north = new ViewItem(1, "north");
+        var south = new ViewItem(2, "south");
+        list.AddRange(new[] { north, south });
+
+        using var view = new GroupedReactiveView<ViewItem, string>(
+            list,
+            static item => item.Region,
+            ImmediateScheduler.Instance,
+            TimeSpan.Zero);
+
+        view.Keys.Should().BeEquivalentTo(new[] { "north", "south" });
+        view.Values.SelectMany(static group => group).Should().BeEquivalentTo(new[] { north, south });
+        view["north"].Should().ContainSingle().Which.Should().Be(north);
+        view.TryGetValue("north", out var northGroup).Should().BeTrue();
+        northGroup.Should().ContainSingle().Which.Should().Be(north);
+        view.TryGetValue("missing", out var missing).Should().BeFalse();
+        missing.Should().BeEmpty();
+        ((IEnumerable)view).Cast<KeyValuePair<string, IReadOnlyList<ViewItem>>>()
+            .Should().HaveCount(2);
+        view.Refresh();
+
+        var changedScore = north with { Score = 10 };
+        list.Update(north, changedScore);
+        await WaitForPipeline();
+        view["north"].Should().ContainSingle().Which.Should().Be(changedScore);
+
+        var movedRegion = changedScore with { Region = "south" };
+        list.Update(changedScore, movedRegion);
+        await WaitForPipeline();
+        view.ContainsKey("north").Should().BeFalse();
+        view["south"].Should().BeEquivalentTo(new[] { south, movedRegion });
+
+        list.Remove(south);
+        await WaitForPipeline();
+        view["south"].Should().ContainSingle().Which.Should().Be(movedRegion);
+
+        list.Remove(movedRegion);
+        await WaitForPipeline();
+        view.Should().BeEmpty();
+
+        list.Add(north);
+        await WaitForPipeline();
+        list.Clear();
+        await WaitForPipeline();
+        view.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Dynamic filtered views should rebuild on filter changes and track source changes.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task DynamicFilteredReactiveView_FilterAndSourceChanges_ShouldRebuildAndTrackTransitions()
+    {
+        using var list = new ReactiveList<int>();
+        list.AddRange(new[] { 1, 2, 3 });
+        using var filters = new BehaviorSubject<Func<int, bool>>(static item => item >= 2);
+
+        using var view = new DynamicFilteredReactiveView<int>(
+            list,
+            filters,
+            ImmediateScheduler.Instance,
+            TimeSpan.Zero);
+
+        await WaitForPipeline();
+        view.Items.Should().Equal(2, 3);
+        view[0].Should().Be(2);
+
+        filters.OnNext(null!);
+        await WaitForPipeline();
+        view.Items.Should().Equal(1, 2, 3);
+
+        filters.OnNext(static item => item % 2 == 0);
+        await WaitForPipeline();
+        view.Items.Should().Equal(2);
+
+        list.Add(4);
+        await WaitForPipeline();
+        view.Items.Should().Equal(2, 4);
+
+        list.Update(2, 5);
+        await WaitForPipeline();
+        view.Items.Should().Equal(4);
+
+        list.Update(1, 6);
+        await WaitForPipeline();
+        view.Items.Should().Equal(4, 6);
+
+        view.Refresh();
+        view.Items.Should().Equal(6, 4);
+
+        list.Update(4, 8);
+        await WaitForPipeline();
+        view.Items.Should().Equal(6, 8);
+
+        list.Remove(6);
+        await WaitForPipeline();
+        view.Items.Should().Equal(8);
+
+        list.Move(2, 0);
+        await WaitForPipeline();
+        view.Items.Should().Equal(8);
+
+        list.Clear();
+        await WaitForPipeline();
+        view.Items.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Dynamic reactive views should apply single and batch stream actions.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task DynamicReactiveView_StreamActions_ShouldApplyCurrentFilterAndBatches()
+    {
+        using var source = new ReactiveSourceHarness<int>(new[] { 1, 2, 3 });
+        using var filters = new BehaviorSubject<Func<int, bool>>(static item => item % 2 == 0);
+
+        using var view = new DynamicReactiveView<int>(
+            source,
+            filters,
+            TimeSpan.Zero,
+            ImmediateScheduler.Instance);
+
+        view.Items.Should().Equal(2);
+
+        source.AddItem(4);
+        source.Emit(new CacheNotify<int>(CacheAction.Added, 4));
+        source.AddItem(5);
+        source.Emit(new CacheNotify<int>(CacheAction.Added, 5));
+        await WaitForPipeline();
+        view.Items.Should().Equal(2, 4);
+
+        source.RemoveItem(2);
+        source.Emit(new CacheNotify<int>(CacheAction.Removed, 2));
+        await WaitForPipeline();
+        view.Items.Should().Equal(4);
+
+        source.AddItems(new[] { 6, 7 });
+        source.Emit(new CacheNotify<int>(CacheAction.BatchAdded, default, CreateBatch(6, 7)));
+        await WaitForPipeline();
+        view.Items.Should().Equal(4, 6);
+
+        source.RemoveItems(new[] { 4, 6 });
+        source.Emit(new CacheNotify<int>(CacheAction.BatchRemoved, default, CreateBatch(4, 6)));
+        await WaitForPipeline();
+        view.Items.Should().BeEmpty();
+
+        source.ClearItems();
+        source.Emit(new CacheNotify<int>(CacheAction.Cleared, default));
+        await WaitForPipeline();
+        view.Items.Should().BeEmpty();
+
+        filters.OnNext(static _ => true);
+        await WaitForPipeline();
+        source.AddItem(9);
+        source.Emit(new CacheNotify<int>(CacheAction.Added, 9));
+        await WaitForPipeline();
+        view.Items.Should().Equal(9);
+    }
+
+#if NET8_0_OR_GREATER || NETFRAMEWORK
+    /// <summary>
+    /// Secondary-index dictionary views should remove values when updates leave the index.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task SecondaryIndexReactiveView_DictionaryUpdates_ShouldRemoveValuesThatLeaveTheIndex()
+    {
+        using var dictionary = new QuaternaryDictionary<int, ViewItem>();
+        var north = new ViewItem(1, "north");
+        dictionary.Add(1, north);
+        dictionary.Add(2, new ViewItem(2, "south"));
+        dictionary.AddValueIndex("region", static item => item.Region);
+
+        using var view = new SecondaryIndexReactiveView<int, ViewItem, string>(
+            dictionary,
+            "region",
+            "north",
+            ImmediateScheduler.Instance,
+            TimeSpan.Zero);
+
+        view.Items.Should().ContainSingle().Which.Should().Be(north);
+        view.Count.Should().Be(1);
+        view[0].Should().Be(north);
+        view.ToProperty(out var outCollection).Should().BeSameAs(view);
+        outCollection.Should().BeSameAs(view.Items);
+        view.ToProperty(collection => collection.Should().BeSameAs(view.Items)).Should().BeSameAs(view);
+        view.Refresh();
+        view.GetEnumerator().MoveNext().Should().BeTrue();
+
+        dictionary.AddOrUpdate(1, north with { Region = "south" });
+        await WaitForPipeline();
+        view.Items.Should().BeEmpty();
+
+        var newNorth = new ViewItem(3, "north");
+        dictionary.AddOrUpdate(3, newNorth);
+        await WaitForPipeline();
+        view.Items.Should().ContainSingle().Which.Should().Be(newNorth);
+
+        dictionary.Remove(3);
+        await WaitForPipeline();
+        view.Items.Should().BeEmpty();
+
+        dictionary.AddOrUpdate(4, new ViewItem(4, "north"));
+        await WaitForPipeline();
+        dictionary.Clear();
+        await WaitForPipeline();
+        view.Items.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Dynamic secondary-index views should track key changes and dictionary updates.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+    [Test]
+    public async Task DynamicSecondaryIndexViews_KeyChangesAndDictionaryUpdates_ShouldTrackCurrentKeys()
+    {
+        using var list = new QuaternaryList<ViewItem>();
+        var north = new ViewItem(1, "north");
+        var south = new ViewItem(2, "south");
+        list.Add(north);
+        list.Add(south);
+        list.AddIndex("region", static item => item.Region);
+        using var listKeys = new BehaviorSubject<string[]>(new[] { "north" });
+
+        using var listView = new DynamicSecondaryIndexReactiveView<ViewItem, string>(
+            list,
+            "region",
+            listKeys,
+            ImmediateScheduler.Instance,
+            TimeSpan.Zero);
+
+        listView.Items.Should().ContainSingle().Which.Should().Be(north);
+        listView.Count.Should().Be(1);
+        listView[0].Should().Be(north);
+        listView.ToProperty(out var listOutCollection).Should().BeSameAs(listView);
+        listOutCollection.Should().BeSameAs(listView.Items);
+        listView.ToProperty(collection => collection.Should().BeSameAs(listView.Items)).Should().BeSameAs(listView);
+        listView.Refresh();
+        listView.GetEnumerator().MoveNext().Should().BeTrue();
+
+        list.Remove(north);
+        await WaitForPipeline();
+        listView.Items.Should().BeEmpty();
+
+        list.Add(north);
+        await WaitForPipeline();
+        listView.Items.Should().ContainSingle().Which.Should().Be(north);
+
+        listKeys.OnNext(new[] { "south" });
+        await WaitForPipeline();
+        listView.Items.Should().ContainSingle().Which.Should().Be(south);
+
+        var secondSouth = new ViewItem(3, "south");
+        list.Add(secondSouth);
+        await WaitForPipeline();
+        listView.Items.Should().BeEquivalentTo(new[] { south, secondSouth });
+
+        list.ReplaceAll(new[] { north });
+        await WaitForPipeline();
+        listView.Items.Should().BeEmpty();
+
+        using var dictionary = new QuaternaryDictionary<int, ViewItem>();
+        dictionary.Add(1, north);
+        dictionary.Add(2, south);
+        dictionary.AddValueIndex("region", static item => item.Region);
+        using var dictionaryKeys = new BehaviorSubject<string[]>(new[] { "north" });
+
+        using var dictionaryView = new DynamicSecondaryIndexDictionaryReactiveView<int, ViewItem, string>(
+            dictionary,
+            "region",
+            dictionaryKeys,
+            ImmediateScheduler.Instance,
+            TimeSpan.Zero);
+
+        dictionaryView.Items.Should().ContainSingle().Which.Should().Be(new KeyValuePair<int, ViewItem>(1, north));
+        dictionaryView.Count.Should().Be(1);
+        dictionaryView[0].Key.Should().Be(1);
+        dictionaryView.ToProperty(out var dictionaryOutCollection).Should().BeSameAs(dictionaryView);
+        dictionaryOutCollection.Should().BeSameAs(dictionaryView.Items);
+        dictionaryView.ToProperty(collection => collection.Should().BeSameAs(dictionaryView.Items)).Should().BeSameAs(dictionaryView);
+        dictionaryView.Refresh();
+        dictionaryView.GetEnumerator().MoveNext().Should().BeTrue();
+
+        dictionary.AddOrUpdate(1, north with { Region = "south" });
+        await WaitForPipeline();
+        dictionaryView.Items.Should().BeEmpty();
+
+        dictionary.AddOrUpdate(4, new ViewItem(4, "north"));
+        await WaitForPipeline();
+        dictionaryView.Items.Select(static item => item.Key).Should().Contain(4);
+
+        dictionary.AddOrUpdate(4, new ViewItem(4, "north", Score: 10));
+        await WaitForPipeline();
+        dictionaryView.Items.Single(static item => item.Key == 4).Value.Score.Should().Be(10);
+
+        dictionaryKeys.OnNext(new[] { "south" });
+        await WaitForPipeline();
+        dictionaryView.Items.Select(static item => item.Key).Should().BeEquivalentTo(new[] { 1, 2 });
+
+        dictionary.AddOrUpdate(5, new ViewItem(5, "north"));
+        await WaitForPipeline();
+        dictionary.AddOrUpdate(5, new ViewItem(5, "south"));
+        await WaitForPipeline();
+        dictionaryView.Items.Select(static item => item.Key).Should().Contain(5);
+
+        var thirdSouth = new ViewItem(3, "south");
+        dictionary.AddOrUpdate(3, thirdSouth);
+        await WaitForPipeline();
+        dictionaryView.Items.Select(static item => item.Key).Should().Contain(3);
+
+        dictionary.Remove(1);
+        await WaitForPipeline();
+        dictionaryView.Items.Select(static item => item.Key).Should().NotContain(1);
+
+        dictionary.Clear();
+        await WaitForPipeline();
+        dictionaryView.Items.Should().BeEmpty();
+    }
+#endif
+
+    private static async Task WaitForPipeline() => await Task.Delay(30);
+
+    private static PooledBatch<T> CreateBatch<T>(params T[] items)
+    {
+        var array = ArrayPool<T>.Shared.Rent(items.Length);
+        Array.Copy(items, array, items.Length);
+        return new PooledBatch<T>(array, items.Length);
+    }
+
+    private sealed record ViewItem(int Id, string Region, int Score = 0);
+
+    private sealed class ReactiveSourceHarness<T> : IReactiveSource<T>
+        where T : notnull
+    {
+        private readonly List<T> _items;
+        private readonly Subject<CacheNotify<T>> _stream = new();
+
+        public ReactiveSourceHarness(IEnumerable<T> items) => _items = new List<T>(items);
+
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+        public int Count => _items.Count;
+
+        public bool IsDisposed { get; private set; }
+
+        public bool IsReadOnly => false;
+
+        public IObservable<CacheNotify<T>> Stream => _stream.AsObservable();
+
+        public long Version { get; private set; }
+
+        public void AddItem(T item)
+        {
+            _items.Add(item);
+            Version++;
+        }
+
+        public void AddItems(IEnumerable<T> items)
+        {
+            _items.AddRange(items);
+            Version++;
+        }
+
+        public void ClearItems()
+        {
+            _items.Clear();
+            Version++;
+        }
+
+        public void Dispose()
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+
+            IsDisposed = true;
+            _stream.Dispose();
+        }
+
+        public void Emit(CacheNotify<T> notification) => _stream.OnNext(notification);
+
+        public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+
+        public void RemoveItem(T item)
+        {
+            _items.Remove(item);
+            Version++;
+        }
+
+        public void RemoveItems(IEnumerable<T> items)
+        {
+            foreach (var item in items)
+            {
+                _items.Remove(item);
+            }
+
+            Version++;
+        }
+
+        public T[] ToArray() => _items.ToArray();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void RaiseReset() =>
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+    }
+}

--- a/src/ReactiveList.Test/ViewToPropertyTests.cs
+++ b/src/ReactiveList.Test/ViewToPropertyTests.cs
@@ -10,7 +10,7 @@ using CP.Reactive.Collections;
 using CP.Reactive.Core;
 using CP.Reactive.Views;
 using FluentAssertions;
-using Xunit;
+using TUnit.Core;
 
 namespace ReactiveList.Test;
 
@@ -22,7 +22,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// ReactiveView ToProperty with action setter should set property and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReactiveView_ToPropertyAction_ShouldSetPropertyAndReturnSameInstance()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -44,7 +44,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// ReactiveView ToProperty with action setter should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReactiveView_ToPropertyAction_WithNullSetter_ShouldThrow()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -65,7 +65,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// ReactiveView ToProperty with out parameter should set collection and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void ReactiveView_ToPropertyOut_ShouldSetCollectionAndReturnSameInstance()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -83,11 +83,11 @@ public class ViewToPropertyTests
         collection.Should().BeSameAs(view.Items);
     }
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
     /// <summary>
     /// DynamicReactiveView ToProperty with action setter should set property and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicReactiveView_ToPropertyAction_ShouldSetPropertyAndReturnSameInstance()
     {
         using var list = new QuaternaryList<string>();
@@ -110,7 +110,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicReactiveView ToProperty with action setter should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicReactiveView_ToPropertyAction_WithNullSetter_ShouldThrow()
     {
         using var list = new QuaternaryList<string>();
@@ -131,7 +131,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicReactiveView ToProperty with out parameter should set collection and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicReactiveView_ToPropertyOut_ShouldSetCollectionAndReturnSameInstance()
     {
         using var list = new QuaternaryList<string>();
@@ -154,7 +154,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// SortedReactiveView ToProperty with action setter should set property and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void SortedReactiveView_ToPropertyAction_ShouldSetPropertyAndReturnSameInstance()
     {
         using var list = new ReactiveList<int>();
@@ -179,7 +179,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// SortedReactiveView ToProperty with action setter should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void SortedReactiveView_ToPropertyAction_WithNullSetter_ShouldThrow()
     {
         using var list = new ReactiveList<int>();
@@ -199,7 +199,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// SortedReactiveView ToProperty with out parameter should set collection and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void SortedReactiveView_ToPropertyOut_ShouldSetCollectionAndReturnSameInstance()
     {
         using var list = new ReactiveList<int>();
@@ -223,7 +223,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// FilteredReactiveView ToProperty with action setter should set property and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void FilteredReactiveView_ToPropertyAction_ShouldSetPropertyAndReturnSameInstance()
     {
         using var list = new ReactiveList<int>();
@@ -246,7 +246,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// FilteredReactiveView ToProperty with action setter should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void FilteredReactiveView_ToPropertyAction_WithNullSetter_ShouldThrow()
     {
         using var list = new ReactiveList<int>();
@@ -266,7 +266,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// FilteredReactiveView ToProperty with out parameter should set collection and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void FilteredReactiveView_ToPropertyOut_ShouldSetCollectionAndReturnSameInstance()
     {
         using var list = new ReactiveList<int>();
@@ -288,7 +288,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// GroupedReactiveView ToProperty with action setter should set property and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void GroupedReactiveView_ToPropertyAction_ShouldSetPropertyAndReturnSameInstance()
     {
         using var list = new ReactiveList<string>();
@@ -311,7 +311,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// GroupedReactiveView ToProperty with action setter should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void GroupedReactiveView_ToPropertyAction_WithNullSetter_ShouldThrow()
     {
         using var list = new ReactiveList<string>();
@@ -331,7 +331,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// GroupedReactiveView ToProperty with out parameter should set collection and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void GroupedReactiveView_ToPropertyOut_ShouldSetCollectionAndReturnSameInstance()
     {
         using var list = new ReactiveList<string>();
@@ -353,7 +353,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// GroupedReactiveView Items property should be same as Groups property.
     /// </summary>
-    [Fact]
+    [Test]
     public void GroupedReactiveView_Items_ShouldBeSameAsGroups()
     {
         using var list = new ReactiveList<string>();
@@ -370,7 +370,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicFilteredReactiveView ToProperty with action setter should set property and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicFilteredReactiveView_ToPropertyAction_ShouldSetPropertyAndReturnSameInstance()
     {
         using var list = new ReactiveList<int>();
@@ -393,7 +393,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicFilteredReactiveView ToProperty with action setter should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicFilteredReactiveView_ToPropertyAction_WithNullSetter_ShouldThrow()
     {
         using var list = new ReactiveList<int>();
@@ -414,7 +414,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicFilteredReactiveView ToProperty with out parameter should set collection and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicFilteredReactiveView_ToPropertyOut_ShouldSetCollectionAndReturnSameInstance()
     {
         using var list = new ReactiveList<int>();
@@ -433,11 +433,11 @@ public class ViewToPropertyTests
         collection.Should().BeSameAs(view.Items);
     }
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
     /// <summary>
     /// SecondaryIndexReactiveView ToProperty with action setter should set property and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void SecondaryIndexReactiveView_ToPropertyAction_ShouldSetPropertyAndReturnSameInstance()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();
@@ -464,7 +464,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// SecondaryIndexReactiveView ToProperty with action setter should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void SecondaryIndexReactiveView_ToPropertyAction_WithNullSetter_ShouldThrow()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();
@@ -486,7 +486,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// SecondaryIndexReactiveView ToProperty with out parameter should set collection and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void SecondaryIndexReactiveView_ToPropertyOut_ShouldSetCollectionAndReturnSameInstance()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();
@@ -510,7 +510,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicSecondaryIndexReactiveView ToProperty with action setter should set property and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicSecondaryIndexReactiveView_ToPropertyAction_ShouldSetPropertyAndReturnSameInstance()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -536,7 +536,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicSecondaryIndexReactiveView ToProperty with action setter should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicSecondaryIndexReactiveView_ToPropertyAction_WithNullSetter_ShouldThrow()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -559,7 +559,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicSecondaryIndexReactiveView ToProperty with out parameter should set collection and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicSecondaryIndexReactiveView_ToPropertyOut_ShouldSetCollectionAndReturnSameInstance()
     {
         using var list = new QuaternaryList<TestPerson>();
@@ -583,7 +583,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicSecondaryIndexDictionaryReactiveView ToProperty with action setter should set property and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicSecondaryIndexDictionaryReactiveView_ToPropertyAction_ShouldSetPropertyAndReturnSameInstance()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();
@@ -609,7 +609,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicSecondaryIndexDictionaryReactiveView ToProperty with action setter should throw when setter is null.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicSecondaryIndexDictionaryReactiveView_ToPropertyAction_WithNullSetter_ShouldThrow()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();
@@ -632,7 +632,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicSecondaryIndexDictionaryReactiveView ToProperty with out parameter should set collection and return same instance.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicSecondaryIndexDictionaryReactiveView_ToPropertyOut_ShouldSetCollectionAndReturnSameInstance()
     {
         using var dict = new QuaternaryDictionary<int, TestPerson>();
@@ -657,7 +657,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// All views should implement IReactiveView interface.
     /// </summary>
-    [Fact]
+    [Test]
     public void AllViews_ShouldImplementIReactiveViewInterface()
     {
         var subject = new Subject<CacheNotify<string>>();
@@ -675,7 +675,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// SortedReactiveView should implement IReactiveView interface.
     /// </summary>
-    [Fact]
+    [Test]
     public void SortedReactiveView_ShouldImplementIReactiveViewInterface()
     {
         using var list = new ReactiveList<int>();
@@ -692,7 +692,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// FilteredReactiveView should implement IReactiveView interface.
     /// </summary>
-    [Fact]
+    [Test]
     public void FilteredReactiveView_ShouldImplementIReactiveViewInterface()
     {
         using var list = new ReactiveList<int>();
@@ -709,7 +709,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// GroupedReactiveView should implement IReactiveView interface.
     /// </summary>
-    [Fact]
+    [Test]
     public void GroupedReactiveView_ShouldImplementIReactiveViewInterface()
     {
         using var list = new ReactiveList<string>();
@@ -726,7 +726,7 @@ public class ViewToPropertyTests
     /// <summary>
     /// DynamicFilteredReactiveView should implement IReactiveView interface.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicFilteredReactiveView_ShouldImplementIReactiveViewInterface()
     {
         using var list = new ReactiveList<int>();
@@ -741,11 +741,11 @@ public class ViewToPropertyTests
         view.Should().BeAssignableTo<IReactiveView<DynamicFilteredReactiveView<int>, int>>();
     }
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
     /// <summary>
     /// DynamicReactiveView should implement IReactiveView interface.
     /// </summary>
-    [Fact]
+    [Test]
     public void DynamicReactiveView_ShouldImplementIReactiveViewInterface()
     {
         using var list = new QuaternaryList<string>();

--- a/src/ReactiveList/Collections/IReactiveSource.cs
+++ b/src/ReactiveList/Collections/IReactiveSource.cs
@@ -49,7 +49,7 @@ public interface IReactiveSource<T> : IEnumerable<T>, INotifyCollectionChanged, 
     /// </remarks>
     IObservable<CacheNotify<T>> Stream { get; }
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETFRAMEWORK
     /// <summary>
     /// Creates a snapshot of current items as an array.
     /// </summary>

--- a/src/ReactiveList/Collections/QuadDictionary.cs
+++ b/src/ReactiveList/Collections/QuadDictionary.cs
@@ -1,7 +1,7 @@
-﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System.Buffers;
 using System.Collections;
 using System.Diagnostics;
@@ -258,12 +258,12 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
                 }
 
                 // Clear entry and add to free list
-                if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+                if (CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>())
                 {
                     entry.Key = default!;
                 }
 
-                if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+                if (CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TValue>())
                 {
                     entry.Value = default;
                 }
@@ -291,7 +291,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
         if (_entryIndex > 0)
         {
             _buckets.AsSpan(0, _bucketsLength).Clear();
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<Entry>())
+            if (CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<Entry>())
             {
                 _entries.AsSpan(0, _entryIndex).Clear();
             }
@@ -308,12 +308,13 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
     /// <param name="capacity">The number of entries the dictionary should be able to hold.</param>
     public void EnsureCapacity(int capacity)
     {
-        if (capacity <= _bucketsLength)
+        if (capacity <= _resizeThreshold)
         {
             return;
         }
 
-        var newSize = System.Numerics.BitOperations.RoundUpToPowerOf2((uint)capacity);
+        var requiredBucketCount = (int)Math.Ceiling(capacity / LoadFactor);
+        var newSize = CP.Reactive.Internal.BitOperationsCompat.RoundUpToPowerOf2((uint)requiredBucketCount);
         ResizeTo((int)newSize);
     }
 
@@ -401,7 +402,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
 
         if (_entries != null)
         {
-            ArrayPool<Entry>.Shared.Return(_entries, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<Entry>());
+            ArrayPool<Entry>.Shared.Return(_entries, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<Entry>());
             _entries = null!;
         }
     }
@@ -458,7 +459,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
     /// <remarks>The new capacity is rounded up to the next power of two to optimize memory usage and
     /// performance. This method is intended for internal use and should not be called directly by consumers of the
     /// class.</remarks>
-    private void Resize() => ResizeTo((int)System.Numerics.BitOperations.RoundUpToPowerOf2((uint)_entries.Length * 2));
+    private void Resize() => ResizeTo((int)CP.Reactive.Internal.BitOperationsCompat.RoundUpToPowerOf2((uint)_entries.Length * 2));
 
     /// <summary>
     /// Resizes the internal storage arrays to accommodate the specified number of entries.
@@ -492,7 +493,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
         }
 
         ArrayPool<int>.Shared.Return(_buckets, clearArray: false);
-        ArrayPool<Entry>.Shared.Return(_entries, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<Entry>());
+        ArrayPool<Entry>.Shared.Return(_entries, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<Entry>());
 
         _entries = newEntries;
         _buckets = newBuckets;

--- a/src/ReactiveList/Collections/QuadList.cs
+++ b/src/ReactiveList/Collections/QuadList.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System.Buffers;
 using System.Collections;
 using System.Runtime.CompilerServices;
@@ -133,7 +133,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
             Array.Copy(_items, index + 1, _items, index, _count - index);
         }
 
-        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+        if (CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>())
         {
             _items[_count] = default!;
         }
@@ -178,7 +178,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
     /// </summary>
     public void Clear()
     {
-        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+        if (CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>())
         {
             Array.Clear(_items, 0, _count);
         }
@@ -234,10 +234,13 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
     {
         if (_items != null)
         {
-            ArrayPool<T>.Shared.Return(_items, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+            ArrayPool<T>.Shared.Return(_items, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
             _items = null!;
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void AddAssumeCapacity(T item) => _items[_count++] = item;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowIndexOutOfRange() => throw new IndexOutOfRangeException();
@@ -256,7 +259,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
         var newCapacity = _items.Length == 0 ? MinimumSize : _items.Length * 2;
         if (newCapacity < minCapacity)
         {
-            newCapacity = (int)System.Numerics.BitOperations.RoundUpToPowerOf2((uint)minCapacity);
+            newCapacity = (int)CP.Reactive.Internal.BitOperationsCompat.RoundUpToPowerOf2((uint)minCapacity);
         }
 
         var newItems = ArrayPool<T>.Shared.Rent(newCapacity);
@@ -265,7 +268,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
             Array.Copy(_items, newItems, _count);
         }
 
-        ArrayPool<T>.Shared.Return(_items, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+        ArrayPool<T>.Shared.Return(_items, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
         _items = newItems;
     }
 

--- a/src/ReactiveList/Collections/QuaternaryBase.cs
+++ b/src/ReactiveList/Collections/QuaternaryBase.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
 using System.Buffers;
 using System.Collections.Concurrent;
@@ -69,12 +69,13 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
         new TQuad()
     ];
 
-    private readonly Channel<CacheNotify<TItem>> _eventChannel = Channel.CreateUnbounded<CacheNotify<TItem>>(
-        new UnboundedChannelOptions { SingleReader = true, SingleWriter = false, AllowSynchronousContinuations = false });
-
-    private readonly Subject<CacheNotify<TItem>> _pipeline = new();
-    private readonly CancellationTokenSource _cts = new();
     private readonly SynchronizationContext? _syncContext;
+    private Channel<CacheNotify<TItem>>? _eventChannel;
+    private object? _eventGate;
+    private Subject<CacheNotify<TItem>>? _pipeline;
+    private CancellationTokenSource? _cts;
+    private NotifyCollectionChangedEventHandler? _collectionChanged;
+    private int _eventProcessorStarted;
     private int _hasSubscribers;
     private long _version;
 
@@ -89,13 +90,26 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     {
         // Capture the current synchronization context (UI thread context in WPF/WinForms)
         _syncContext = SynchronizationContext.Current;
-        Task.Factory.StartNew(ProcessEventsAsync, _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
     }
 
     /// <summary>
     /// Occurs when the collection changes.
     /// </summary>
-    public event NotifyCollectionChangedEventHandler? CollectionChanged;
+    public event NotifyCollectionChangedEventHandler? CollectionChanged
+    {
+        add
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            EnsureEventProcessorStarted();
+            _collectionChanged += value;
+        }
+
+        remove => _collectionChanged -= value;
+    }
 
     /// <summary>
     /// Gets the total number of items contained in all quads.
@@ -141,7 +155,8 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
         get
         {
             Volatile.Write(ref _hasSubscribers, 1);
-            return _pipeline.AsObservable();
+            EnsureEventProcessorStarted();
+            return _pipeline!.AsObservable();
         }
     }
 
@@ -237,13 +252,14 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
         Interlocked.Increment(ref _version);
 
         // Fast path: skip channel write if no subscribers and no INCC
-        if (Interlocked.CompareExchange(ref _hasSubscribers, 0, 0) == 0 && CollectionChanged == null)
+        if (!HasChangeObservers())
         {
             batch?.Dispose();
             return;
         }
 
-        _eventChannel.Writer.TryWrite(new(action, item, batch));
+        EnsureEventProcessorStarted();
+        _eventChannel!.Writer.TryWrite(new(action, item, batch));
     }
 
     /// <summary>
@@ -258,6 +274,12 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected void EmitBatchDirect(TItem[] items, int count)
     {
+        if (!HasChangeObservers())
+        {
+            Emit(CacheAction.BatchOperation, default);
+            return;
+        }
+
         var pool = ArrayPool<TItem>.Shared.Rent(count);
         Array.Copy(items, pool, count);
         Emit(CacheAction.BatchOperation, default, new PooledBatch<TItem>(pool, count));
@@ -275,6 +297,12 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected void EmitBatchAddedDirect(TItem[] items, int count)
     {
+        if (!HasChangeObservers())
+        {
+            Emit(CacheAction.BatchAdded, default);
+            return;
+        }
+
         var pool = ArrayPool<TItem>.Shared.Rent(count);
         Array.Copy(items, pool, count);
         Emit(CacheAction.BatchAdded, default, new PooledBatch<TItem>(pool, count));
@@ -295,6 +323,12 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
         if (items == null)
         {
             throw new ArgumentNullException(nameof(items));
+        }
+
+        if (!HasChangeObservers())
+        {
+            Emit(CacheAction.BatchAdded, default);
+            return;
         }
 
         var pool = ArrayPool<TItem>.Shared.Rent(count);
@@ -318,6 +352,12 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected void EmitBatchRemoved(TItem[] items, int count)
     {
+        if (!HasChangeObservers())
+        {
+            Emit(CacheAction.BatchRemoved, default);
+            return;
+        }
+
         var pool = ArrayPool<TItem>.Shared.Rent(count);
         Array.Copy(items, pool, count);
         Emit(CacheAction.BatchRemoved, default, new PooledBatch<TItem>(pool, count));
@@ -336,6 +376,12 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
         if (items == null)
         {
             throw new ArgumentNullException(nameof(items));
+        }
+
+        if (!HasChangeObservers())
+        {
+            Emit(CacheAction.BatchRemoved, default);
+            return;
         }
 
         var pool = ArrayPool<TItem>.Shared.Rent(count);
@@ -393,15 +439,15 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
         {
             if (disposing)
             {
-                _cts.Cancel();
-                _cts.Dispose();
+                _cts?.Cancel();
+                _cts?.Dispose();
                 foreach (var l in Locks)
                 {
                     l.Dispose();
                 }
 
-                _pipeline.OnCompleted();
-                _pipeline.Dispose();
+                _pipeline?.OnCompleted();
+                _pipeline?.Dispose();
             }
 
             IsDisposed = true;
@@ -417,16 +463,24 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     /// <returns>A task that represents the asynchronous operation.</returns>
     private async Task ProcessEventsAsync()
     {
-        var reader = _eventChannel.Reader;
+        var channel = _eventChannel;
+        var pipeline = _pipeline;
+        var cts = _cts;
+        if (channel == null || pipeline == null || cts == null)
+        {
+            return;
+        }
+
+        var reader = channel.Reader;
         try
         {
-            while (await reader.WaitToReadAsync(_cts.Token).ConfigureAwait(false))
+            while (await reader.WaitToReadAsync(cts.Token).ConfigureAwait(false))
             {
                 while (reader.TryRead(out var evt))
                 {
-                    _pipeline.OnNext(evt);
+                    pipeline.OnNext(evt);
 
-                    if (CollectionChanged != null)
+                    if (_collectionChanged != null)
                     {
                         InvokeLegacyINCC(evt);
                     }
@@ -449,7 +503,7 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     /// <param name="evt">The cache notification event containing information about the collection change to be propagated.</param>
     private void InvokeLegacyINCC(CacheNotify<TItem> evt)
     {
-        var handler = CollectionChanged;
+        var handler = _collectionChanged;
         if (handler == null)
         {
             evt.Batch?.Dispose();
@@ -471,7 +525,7 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
                 CacheAction.Added => NotifyCollectionChangedAction.Add,
                 CacheAction.Removed => NotifyCollectionChangedAction.Remove,
                 CacheAction.Cleared => NotifyCollectionChangedAction.Reset,
-                CacheAction.Updated => NotifyCollectionChangedAction.Replace,
+                CacheAction.Updated => NotifyCollectionChangedAction.Reset,
                 _ => NotifyCollectionChangedAction.Reset
             };
 
@@ -496,6 +550,39 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
         {
             // Fallback: invoke directly if no sync context was captured
             handler.Invoke(this, args);
+        }
+    }
+
+    private bool HasChangeObservers() =>
+        Interlocked.CompareExchange(ref _hasSubscribers, 0, 0) != 0 || _collectionChanged != null;
+
+    private void EnsureEventProcessorStarted()
+    {
+        if (Volatile.Read(ref _eventProcessorStarted) != 0)
+        {
+            return;
+        }
+
+        var gate = _eventGate;
+        if (gate == null)
+        {
+            var newGate = new object();
+            gate = Interlocked.CompareExchange(ref _eventGate, newGate, null) ?? newGate;
+        }
+
+        lock (gate)
+        {
+            if (_eventProcessorStarted != 0)
+            {
+                return;
+            }
+
+            _eventChannel = Channel.CreateUnbounded<CacheNotify<TItem>>(
+                new UnboundedChannelOptions { SingleReader = true, SingleWriter = false, AllowSynchronousContinuations = false });
+            _pipeline = new();
+            _cts = new();
+            Volatile.Write(ref _eventProcessorStarted, 1);
+            Task.Factory.StartNew(ProcessEventsAsync, _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
     }
 }

--- a/src/ReactiveList/Collections/QuaternaryDictionary.cs
+++ b/src/ReactiveList/Collections/QuaternaryDictionary.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
 using System.Buffers;
 using System.Collections;
@@ -209,13 +209,19 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     /// <param name="value">When this method returns, contains the value if found.</param>
     /// <returns>true if the key was found; otherwise, false.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if NETFRAMEWORK
+    public bool TryGetValue(TKey key, out TValue value)
+#else
     public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+#endif
     {
         var idx = GetShard(key);
         Locks[idx].EnterReadLock();
         try
         {
-            return Quads[idx].TryGetValue(key, out value);
+            var found = Quads[idx].TryGetValue(key, out var result);
+            value = result!;
+            return found;
         }
         finally
         {
@@ -383,7 +389,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     /// <param name="keys">The collection of keys to remove.</param>
     public void RemoveKeys(IEnumerable<TKey> keys)
     {
-        ArgumentNullException.ThrowIfNull(keys);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(keys);
 
         // Fast path for arrays
         if (keys is TKey[] array)
@@ -410,7 +416,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     /// <returns>The number of entries removed from the dictionary.</returns>
     public int RemoveMany(Func<KeyValuePair<TKey, TValue>, bool> predicate)
     {
-        ArgumentNullException.ThrowIfNull(predicate);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(predicate);
 
         var totalRemoved = 0;
 
@@ -438,7 +444,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
                             {
                                 var newBuffer = ArrayPool<TKey>.Shared.Rent(keysBuffer.Length * 2);
                                 keysBuffer.AsSpan(0, keysCount).CopyTo(newBuffer);
-                                ArrayPool<TKey>.Shared.Return(keysBuffer, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TKey>());
+                                ArrayPool<TKey>.Shared.Return(keysBuffer, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
                                 keysBuffer = newBuffer;
                             }
 
@@ -475,7 +481,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
         }
         finally
         {
-            ArrayPool<TKey>.Shared.Return(keysBuffer, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TKey>());
+            ArrayPool<TKey>.Shared.Return(keysBuffer, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
         }
 
         return totalRemoved;
@@ -487,7 +493,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     /// <param name="editAction">An action that receives the dictionary interface to perform modifications.</param>
     public void Edit(Action<IDictionary<TKey, TValue>> editAction)
     {
-        ArgumentNullException.ThrowIfNull(editAction);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(editAction);
 
         // Acquire all locks for the edit operation
         for (var i = 0; i < ShardCount; i++)
@@ -520,7 +526,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     /// <exception cref="ArgumentNullException">Thrown when array is null.</exception>
     public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
     {
-        ArgumentNullException.ThrowIfNull(array);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(array);
 
         for (var i = 0; i < ShardCount; i++)
         {
@@ -603,115 +609,74 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
             return;
         }
 
-        var bucketCountsArray = new int[ShardCount];
-        var bucketIndicesArray = new int[ShardCount];
-        var itemsSpan = items.AsSpan();
-
-        for (var i = 0; i < count; i++)
-        {
-            var shardIdx = GetShard(itemsSpan[i].Key);
-            bucketCountsArray[shardIdx]++;
-        }
-
-        var bucketArrays = new KeyValuePair<TKey, TValue>[ShardCount][];
-
-        for (var i = 0; i < ShardCount; i++)
-        {
-            bucketArrays[i] = bucketCountsArray[i] > 0 ? ArrayPool<KeyValuePair<TKey, TValue>>.Shared.Rent(bucketCountsArray[i]) : [];
-        }
+        var rentedShardIndexes = (int[]?)null;
+        var shardIndexes = count <= 1024
+            ? stackalloc int[count]
+            : (rentedShardIndexes = ArrayPool<int>.Shared.Rent(count)).AsSpan(0, count);
 
         try
         {
+            Span<int> shardCounts = stackalloc int[ShardCount];
+            shardCounts.Clear();
+            var itemsSpan = items.AsSpan();
             for (var i = 0; i < count; i++)
             {
-                var kvp = itemsSpan[i];
-                var shardIdx = GetShard(kvp.Key);
-                bucketArrays[shardIdx][bucketIndicesArray[shardIdx]++] = kvp;
+                var shardIndex = GetShard(itemsSpan[i].Key);
+                shardIndexes[i] = shardIndex;
+                shardCounts[shardIndex]++;
             }
 
-            if (count >= ParallelThreshold)
+            for (var i = 0; i < ShardCount; i++)
             {
-                Parallel.For(0, ShardCount, sIdx =>
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        return;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var dict = Quads[sIdx];
-                        dict.EnsureCapacity(dict.Count + bucketCount);
-
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var kvp = bucket[i];
-                            ref var valueRef = ref dict.GetValueRefOrAddDefault(kvp.Key, out _);
-                            valueRef = kvp.Value;
-                            if (hasIndices)
-                            {
-                                NotifyIndicesAdded(kvp.Value);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                });
+                Locks[i].EnterWriteLock();
             }
-            else
+
+            try
             {
-                for (var sIdx = 0; sIdx < ShardCount; sIdx++)
+                for (var i = 0; i < ShardCount; i++)
                 {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
+                    if (shardCounts[i] > 0)
                     {
-                        continue;
+                        var dict = Quads[i];
+                        dict.EnsureCapacity(dict.Count + shardCounts[i]);
+                    }
+                }
+
+                var hasIndices = !Indices.IsEmpty;
+                for (var i = 0; i < count; i++)
+                {
+                    var kvp = itemsSpan[i];
+                    var dict = Quads[shardIndexes[i]];
+                    ref var valueRef = ref dict.GetValueRefOrAddDefault(kvp.Key, out var exists);
+                    if (hasIndices && exists)
+                    {
+                        NotifyIndicesRemoved(valueRef!);
                     }
 
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
+                    valueRef = kvp.Value;
+                    if (hasIndices)
                     {
-                        var dict = Quads[sIdx];
-                        dict.EnsureCapacity(dict.Count + bucketCount);
-
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var kvp = bucket[i];
-                            ref var valueRef = ref dict.GetValueRefOrAddDefault(kvp.Key, out _);
-                            valueRef = kvp.Value;
-                            if (hasIndices)
-                            {
-                                NotifyIndicesAdded(kvp.Value);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
+                        NotifyIndicesAdded(kvp.Value);
                     }
                 }
             }
-
-            EmitBatchAddedDirect(items, count);
+            finally
+            {
+                for (var i = ShardCount - 1; i >= 0; i--)
+                {
+                    Locks[i].ExitWriteLock();
+                }
+            }
         }
         finally
         {
-            for (var i = 0; i < ShardCount; i++)
+            if (rentedShardIndexes != null)
             {
-                if (bucketCountsArray[i] > 0)
-                {
-                    ArrayPool<KeyValuePair<TKey, TValue>>.Shared.Return(bucketArrays[i], clearArray: true);
-                }
+                ArrayPool<int>.Shared.Return(rentedShardIndexes, clearArray: false);
             }
         }
+
+        EmitBatchAddedDirect(items, count);
     }
 
     /// <summary>
@@ -730,114 +695,73 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
             return;
         }
 
-        var bucketCountsArray = new int[ShardCount];
-        var bucketIndicesArray = new int[ShardCount];
-
-        for (var i = 0; i < count; i++)
-        {
-            var shardIdx = GetShard(items[i].Key);
-            bucketCountsArray[shardIdx]++;
-        }
-
-        var bucketArrays = new KeyValuePair<TKey, TValue>[ShardCount][];
-
-        for (var i = 0; i < ShardCount; i++)
-        {
-            bucketArrays[i] = bucketCountsArray[i] > 0 ? ArrayPool<KeyValuePair<TKey, TValue>>.Shared.Rent(bucketCountsArray[i]) : [];
-        }
+        var rentedShardIndexes = (int[]?)null;
+        var shardIndexes = count <= 1024
+            ? stackalloc int[count]
+            : (rentedShardIndexes = ArrayPool<int>.Shared.Rent(count)).AsSpan(0, count);
 
         try
         {
+            Span<int> shardCounts = stackalloc int[ShardCount];
+            shardCounts.Clear();
             for (var i = 0; i < count; i++)
             {
-                var kvp = items[i];
-                var shardIdx = GetShard(kvp.Key);
-                bucketArrays[shardIdx][bucketIndicesArray[shardIdx]++] = kvp;
+                var shardIndex = GetShard(items[i].Key);
+                shardIndexes[i] = shardIndex;
+                shardCounts[shardIndex]++;
             }
 
-            if (count >= ParallelThreshold)
+            for (var i = 0; i < ShardCount; i++)
             {
-                Parallel.For(0, ShardCount, sIdx =>
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        return;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var dict = Quads[sIdx];
-                        dict.EnsureCapacity(dict.Count + bucketCount);
-
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var kvp = bucket[i];
-                            ref var valueRef = ref dict.GetValueRefOrAddDefault(kvp.Key, out _);
-                            valueRef = kvp.Value;
-                            if (hasIndices)
-                            {
-                                NotifyIndicesAdded(kvp.Value);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                });
+                Locks[i].EnterWriteLock();
             }
-            else
+
+            try
             {
-                for (var sIdx = 0; sIdx < ShardCount; sIdx++)
+                for (var i = 0; i < ShardCount; i++)
                 {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
+                    if (shardCounts[i] > 0)
                     {
-                        continue;
+                        var dict = Quads[i];
+                        dict.EnsureCapacity(dict.Count + shardCounts[i]);
+                    }
+                }
+
+                var hasIndices = !Indices.IsEmpty;
+                for (var i = 0; i < count; i++)
+                {
+                    var kvp = items[i];
+                    var dict = Quads[shardIndexes[i]];
+                    ref var valueRef = ref dict.GetValueRefOrAddDefault(kvp.Key, out var exists);
+                    if (hasIndices && exists)
+                    {
+                        NotifyIndicesRemoved(valueRef!);
                     }
 
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
+                    valueRef = kvp.Value;
+                    if (hasIndices)
                     {
-                        var dict = Quads[sIdx];
-                        dict.EnsureCapacity(dict.Count + bucketCount);
-
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var kvp = bucket[i];
-                            ref var valueRef = ref dict.GetValueRefOrAddDefault(kvp.Key, out _);
-                            valueRef = kvp.Value;
-                            if (hasIndices)
-                            {
-                                NotifyIndicesAdded(kvp.Value);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
+                        NotifyIndicesAdded(kvp.Value);
                     }
                 }
             }
-
-            EmitBatchAddedFromList(items, count);
+            finally
+            {
+                for (var i = ShardCount - 1; i >= 0; i--)
+                {
+                    Locks[i].ExitWriteLock();
+                }
+            }
         }
         finally
         {
-            for (var i = 0; i < ShardCount; i++)
+            if (rentedShardIndexes != null)
             {
-                if (bucketCountsArray[i] > 0)
-                {
-                    ArrayPool<KeyValuePair<TKey, TValue>>.Shared.Return(bucketArrays[i], clearArray: true);
-                }
+                ArrayPool<int>.Shared.Return(rentedShardIndexes, clearArray: false);
             }
         }
+
+        EmitBatchAddedFromList(items, count);
     }
 
     /// <summary>
@@ -953,7 +877,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
             {
                 if (bucketCountsArray[i] > 0)
                 {
-                    ArrayPool<TKey>.Shared.Return(bucketArrays[i], clearArray: true);
+                    ArrayPool<TKey>.Shared.Return(bucketArrays[i], clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
                 }
             }
         }
@@ -1071,7 +995,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
             {
                 if (bucketCountsArray[i] > 0)
                 {
-                    ArrayPool<TKey>.Shared.Return(bucketArrays[i], clearArray: true);
+                    ArrayPool<TKey>.Shared.Return(bucketArrays[i], clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
                 }
             }
         }
@@ -1225,10 +1149,16 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
         /// <param name="value">When this method returns, contains the value associated with the specified key, if the key is found;
         /// otherwise, the default value for the type of the value parameter. This parameter is passed uninitialized.</param>
         /// <returns>true if the object that implements the method contains an element with the specified key; otherwise, false.</returns>
+#if NETFRAMEWORK
+        public bool TryGetValue(TKey key, out TValue value)
+#else
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+#endif
         {
             var idx = GetShard(key);
-            return _parent.Quads[idx].TryGetValue(key, out value);
+            var found = _parent.Quads[idx].TryGetValue(key, out var result);
+            value = result!;
+            return found;
         }
 
         /// <summary>

--- a/src/ReactiveList/Collections/QuaternaryList.cs
+++ b/src/ReactiveList/Collections/QuaternaryList.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
 using System.Buffers;
 using System.Collections;
@@ -161,7 +161,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
     /// <returns>The number of elements removed from the collection.</returns>
     public int RemoveMany(Func<T, bool> predicate)
     {
-        ArgumentNullException.ThrowIfNull(predicate);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(predicate);
 
         var totalRemoved = 0;
 
@@ -190,7 +190,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                             {
                                 var newBuffer = ArrayPool<T>.Shared.Rent(removedBuffer.Length * 2);
                                 removedBuffer.AsSpan(0, removedCount).CopyTo(newBuffer);
-                                ArrayPool<T>.Shared.Return(removedBuffer, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+                                ArrayPool<T>.Shared.Return(removedBuffer, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
                                 removedBuffer = newBuffer;
                             }
 
@@ -212,7 +212,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
         }
         finally
         {
-            ArrayPool<T>.Shared.Return(removedBuffer, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+            ArrayPool<T>.Shared.Return(removedBuffer, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
         }
 
         return totalRemoved;
@@ -224,7 +224,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
     /// <param name="editAction">An action that receives an editable list interface to perform modifications.</param>
     public void Edit(Action<ICollection<T>> editAction)
     {
-        ArgumentNullException.ThrowIfNull(editAction);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(editAction);
 
         // Acquire all locks for the edit operation
         for (var i = 0; i < ShardCount; i++)
@@ -257,7 +257,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
     /// <param name="items">The new items to replace all existing items with. Cannot be null.</param>
     public void ReplaceAll(IEnumerable<T> items)
     {
-        ArgumentNullException.ThrowIfNull(items);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(items);
 
         var newItems = items as T[] ?? items.ToArray();
 
@@ -334,7 +334,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                     {
                         if (bucketCountsArray[i] > 0)
                         {
-                            ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+                            ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
                         }
                     }
                 }
@@ -584,110 +584,67 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
             return;
         }
 
-        // Use stack-allocated spans for small counts to avoid heap allocations (non-parallel path)
-        // For parallel path, copy to array since Span cannot be captured in lambdas
-        var bucketCountsArray = new int[ShardCount];
-        var bucketIndicesArray = new int[ShardCount];
-        var itemsSpan = items.AsSpan();
-
-        for (var i = 0; i < count; i++)
-        {
-            var shardIdx = GetShardIndex(itemsSpan[i]);
-            bucketCountsArray[shardIdx]++;
-        }
-
-        var bucketArrays = new T[ShardCount][];
-
-        for (var i = 0; i < ShardCount; i++)
-        {
-            bucketArrays[i] = bucketCountsArray[i] > 0 ? ArrayPool<T>.Shared.Rent(bucketCountsArray[i]) : Array.Empty<T>();
-        }
+        var rentedShardIndexes = (int[]?)null;
+        var shardIndexes = count <= 1024
+            ? stackalloc int[count]
+            : (rentedShardIndexes = ArrayPool<int>.Shared.Rent(count)).AsSpan(0, count);
 
         try
         {
+            Span<int> shardCounts = stackalloc int[ShardCount];
+            shardCounts.Clear();
+            var itemsSpan = items.AsSpan();
             for (var i = 0; i < count; i++)
             {
-                var item = itemsSpan[i];
-                var shardIdx = GetShardIndex(item);
-                bucketArrays[shardIdx][bucketIndicesArray[shardIdx]++] = item;
+                var shardIndex = GetShardIndex(itemsSpan[i]);
+                shardIndexes[i] = shardIndex;
+                shardCounts[shardIndex]++;
             }
 
-            // Insert into shards - use parallel only for large datasets
-            if (count >= ParallelThreshold)
+            for (var i = 0; i < ShardCount; i++)
             {
-                Parallel.For(0, ShardCount, sIdx =>
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        return;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var quad = Quads[sIdx];
-                        quad.AddRange(bucket);
-
-                        if (!Indices.IsEmpty)
-                        {
-                            for (var i = 0; i < bucketCount; i++)
-                            {
-                                NotifyIndicesAdded(bucket[i]);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                });
+                Locks[i].EnterWriteLock();
             }
-            else
+
+            try
             {
-                for (var sIdx = 0; sIdx < ShardCount; sIdx++)
+                for (var i = 0; i < ShardCount; i++)
                 {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
+                    if (shardCounts[i] > 0)
                     {
-                        continue;
+                        var quad = Quads[i];
+                        quad.EnsureCapacity(quad.Count + shardCounts[i]);
                     }
+                }
 
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
+                var hasIndices = !Indices.IsEmpty;
+                for (var i = 0; i < count; i++)
+                {
+                    var item = itemsSpan[i];
+                    Quads[shardIndexes[i]].AddAssumeCapacity(item);
+                    if (hasIndices)
                     {
-                        var quad = Quads[sIdx];
-                        quad.AddRange(bucket);
-
-                        if (!Indices.IsEmpty)
-                        {
-                            for (var i = 0; i < bucketCount; i++)
-                            {
-                                NotifyIndicesAdded(bucket[i]);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
+                        NotifyIndicesAdded(item);
                     }
                 }
             }
-
-            EmitBatchAddedDirect(items, count);
+            finally
+            {
+                for (var i = ShardCount - 1; i >= 0; i--)
+                {
+                    Locks[i].ExitWriteLock();
+                }
+            }
         }
         finally
         {
-            for (var i = 0; i < ShardCount; i++)
+            if (rentedShardIndexes != null)
             {
-                if (bucketCountsArray[i] > 0)
-                {
-                    ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: true);
-                }
+                ArrayPool<int>.Shared.Return(rentedShardIndexes, clearArray: false);
             }
         }
+
+        EmitBatchAddedDirect(items, count);
     }
 
     /// <summary>
@@ -707,106 +664,66 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
             return;
         }
 
-        var bucketCountsArray = new int[ShardCount];
-        var bucketIndicesArray = new int[ShardCount];
-
-        for (var i = 0; i < count; i++)
-        {
-            var shardIdx = GetShardIndex(items[i]);
-            bucketCountsArray[shardIdx]++;
-        }
-
-        var bucketArrays = new T[ShardCount][];
-
-        for (var i = 0; i < ShardCount; i++)
-        {
-            bucketArrays[i] = bucketCountsArray[i] > 0 ? ArrayPool<T>.Shared.Rent(bucketCountsArray[i]) : Array.Empty<T>();
-        }
+        var rentedShardIndexes = (int[]?)null;
+        var shardIndexes = count <= 1024
+            ? stackalloc int[count]
+            : (rentedShardIndexes = ArrayPool<int>.Shared.Rent(count)).AsSpan(0, count);
 
         try
         {
+            Span<int> shardCounts = stackalloc int[ShardCount];
+            shardCounts.Clear();
             for (var i = 0; i < count; i++)
             {
-                var item = items[i];
-                var shardIdx = GetShardIndex(item);
-                bucketArrays[shardIdx][bucketIndicesArray[shardIdx]++] = item;
+                var shardIndex = GetShardIndex(items[i]);
+                shardIndexes[i] = shardIndex;
+                shardCounts[shardIndex]++;
             }
 
-            if (count >= ParallelThreshold)
+            for (var i = 0; i < ShardCount; i++)
             {
-                Parallel.For(0, ShardCount, sIdx =>
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        return;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var quad = Quads[sIdx];
-                        quad.AddRange(bucket);
-
-                        if (!Indices.IsEmpty)
-                        {
-                            for (var i = 0; i < bucketCount; i++)
-                            {
-                                NotifyIndicesAdded(bucket[i]);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                });
+                Locks[i].EnterWriteLock();
             }
-            else
+
+            try
             {
-                for (var sIdx = 0; sIdx < ShardCount; sIdx++)
+                for (var i = 0; i < ShardCount; i++)
                 {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
+                    if (shardCounts[i] > 0)
                     {
-                        continue;
+                        var quad = Quads[i];
+                        quad.EnsureCapacity(quad.Count + shardCounts[i]);
                     }
+                }
 
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
+                var hasIndices = !Indices.IsEmpty;
+                for (var i = 0; i < count; i++)
+                {
+                    var item = items[i];
+                    Quads[shardIndexes[i]].AddAssumeCapacity(item);
+                    if (hasIndices)
                     {
-                        var quad = Quads[sIdx];
-                        quad.AddRange(bucket);
-
-                        if (!Indices.IsEmpty)
-                        {
-                            for (var i = 0; i < bucketCount; i++)
-                            {
-                                NotifyIndicesAdded(bucket[i]);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
+                        NotifyIndicesAdded(item);
                     }
                 }
             }
-
-            EmitBatchAddedFromList(items, count);
+            finally
+            {
+                for (var i = ShardCount - 1; i >= 0; i--)
+                {
+                    Locks[i].ExitWriteLock();
+                }
+            }
         }
         finally
         {
-            for (var i = 0; i < ShardCount; i++)
+            if (rentedShardIndexes != null)
             {
-                if (bucketCountsArray[i] > 0)
-                {
-                    ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: true);
-                }
+                ArrayPool<int>.Shared.Return(rentedShardIndexes, clearArray: false);
             }
         }
+
+        EmitBatchAddedFromList(items, count);
     }
 
     /// <summary>
@@ -922,7 +839,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
             {
                 if (bucketCountsArray[i] > 0)
                 {
-                    ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: true);
+                    ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
                 }
             }
         }
@@ -1039,7 +956,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
             {
                 if (bucketCountsArray[i] > 0)
                 {
-                    ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: true);
+                    ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
                 }
             }
         }

--- a/src/ReactiveList/Collections/ReactiveList.cs
+++ b/src/ReactiveList/Collections/ReactiveList.cs
@@ -42,10 +42,10 @@ public class ReactiveList<T> : IReactiveList<T>
 
 #if NET9_0_OR_GREATER
     [NonSerialized]
-    private readonly Lock _lock = new();
+    private Lock _lock = new();
 #else
     [NonSerialized]
-    private readonly object _lock = new();
+    private object _lock = new();
 #endif
 
     [NonSerialized]
@@ -70,22 +70,22 @@ public class ReactiveList<T> : IReactiveList<T>
     private ReadOnlyObservableCollection<T> _itemsAdded;
 
     [NonSerialized]
-    private ObservableCollection<T>? _itemsAddedCollection;
+    private RangeObservableCollection? _itemsAddedCollection;
 
     [NonSerialized]
     private ReadOnlyObservableCollection<T> _itemsChanged;
 
     [NonSerialized]
-    private ObservableCollection<T>? _itemsChangedCollection;
+    private RangeObservableCollection? _itemsChangedCollection;
 
     [NonSerialized]
     private ReadOnlyObservableCollection<T> _itemsRemoved;
 
     [NonSerialized]
-    private ObservableCollection<T>? _itemsRemovedCollection;
+    private RangeObservableCollection? _itemsRemovedCollection;
 
     [NonSerialized]
-    private ObservableCollection<T>? _observableItems;
+    private RangeObservableCollection? _observableItems;
 
     [NonSerialized]
     private Subject<CacheNotify<T>>? _streamPipeline;
@@ -107,15 +107,35 @@ public class ReactiveList<T> : IReactiveList<T>
     /// Initializes a new instance of the <see cref="ReactiveList{T}"/> class.
     /// </summary>
     /// <param name="items">The items.</param>
+#pragma warning disable CS8618 // Non-nullable fields are initialized by InitializeNonSerializedFields.
     public ReactiveList(IEnumerable<T> items)
-        : this() => AddRange(items);
+    {
+        var itemArray = items as T[] ?? items.ToArray();
+        if (itemArray.Length > 0)
+        {
+            _internalList.AddRange(itemArray);
+        }
+
+        InitializeNonSerializedFields();
+        if (itemArray.Length > 0)
+        {
+            _currentItems!.OnNext(_internalList);
+        }
+    }
+#pragma warning restore CS8618
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReactiveList{T}"/> class.
     /// </summary>
     /// <param name="item">The item.</param>
+#pragma warning disable CS8618 // Non-nullable fields are initialized by InitializeNonSerializedFields.
     public ReactiveList(T item)
-        : this() => Add(item);
+    {
+        _internalList.Add(item);
+        InitializeNonSerializedFields();
+        _currentItems!.OnNext(_internalList);
+    }
+#pragma warning restore CS8618
 
     /// <inheritdoc/>
     public event NotifyCollectionChangedEventHandler? CollectionChanged;
@@ -244,7 +264,7 @@ public class ReactiveList<T> : IReactiveList<T>
         }
     }
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETFRAMEWORK
     /// <summary>
     /// Creates a snapshot of current items as an array.
     /// </summary>
@@ -271,7 +291,12 @@ public class ReactiveList<T> : IReactiveList<T>
 
         lock (_lock)
         {
-            _internalList.EnsureCapacity(_internalList.Count + items.Length);
+            var requiredCapacity = _internalList.Count + items.Length;
+            if (_internalList.Capacity < requiredCapacity)
+            {
+                _internalList.Capacity = requiredCapacity;
+            }
+
             foreach (var item in items)
             {
                 _internalList.Add(item);
@@ -298,7 +323,11 @@ public class ReactiveList<T> : IReactiveList<T>
                 throw new ArgumentException("Destination span is too small.", nameof(destination));
             }
 
+#if NET6_0_OR_GREATER
             CollectionsMarshal.AsSpan(_internalList).CopyTo(destination);
+#else
+            _internalList.ToArray().AsSpan().CopyTo(destination);
+#endif
         }
     }
 
@@ -310,7 +339,14 @@ public class ReactiveList<T> : IReactiveList<T>
     /// The returned span is only valid while no modifications are made to the list.
     /// </remarks>
     /// <returns>A read-only span over the internal items.</returns>
-    public ReadOnlySpan<T> AsSpan() => CollectionsMarshal.AsSpan(_internalList);
+    public ReadOnlySpan<T> AsSpan()
+    {
+#if NET6_0_OR_GREATER
+        return CollectionsMarshal.AsSpan(_internalList);
+#else
+        return _internalList.ToArray().AsSpan();
+#endif
+    }
 
     /// <summary>
     /// Gets a memory region over the internal list for async operations.
@@ -399,10 +435,7 @@ public class ReactiveList<T> : IReactiveList<T>
             _internalList.EnsureCapacity(_internalList.Count + itemArray.Length);
 #endif
             _internalList.AddRange(itemArray);
-            foreach (var item in itemArray)
-            {
-                _observableItems!.Add(item);
-            }
+            _observableItems!.AddRange(itemArray);
 
             NotifyAddedRange(itemArray);
         }
@@ -643,10 +676,7 @@ public class ReactiveList<T> : IReactiveList<T>
         lock (_lock)
         {
             _internalList.InsertRange(index, itemArray);
-            for (var i = 0; i < itemArray.Length; i++)
-            {
-                _observableItems?.Insert(index + i, itemArray[i]);
-            }
+            _observableItems?.InsertRange(index, itemArray);
 
             NotifyAddedRange(itemArray, index);
         }
@@ -870,10 +900,7 @@ public class ReactiveList<T> : IReactiveList<T>
             // Use GetRange + RemoveRange for better performance
             var removed = _internalList.GetRange(index, count).ToArray();
             _internalList.RemoveRange(index, count);
-            for (var i = 0; i < count; i++)
-            {
-                _observableItems!.RemoveAt(index);
-            }
+            _observableItems!.RemoveRange(index, count);
 #else
             var removed = new T[count];
             for (var i = 0; i < count; i++)
@@ -897,16 +924,12 @@ public class ReactiveList<T> : IReactiveList<T>
         {
             var oldItems = _internalList.ToArray();
             _internalList.Clear();
-            _observableItems!.Clear();
 
 #if NET6_0_OR_GREATER
             _internalList.EnsureCapacity(itemArray.Length);
 #endif
             _internalList.AddRange(itemArray);
-            foreach (var item in itemArray)
-            {
-                _observableItems.Add(item);
-            }
+            _observableItems!.ReplaceAll(itemArray);
 
             Interlocked.Increment(ref _version);
 
@@ -1008,14 +1031,7 @@ public class ReactiveList<T> : IReactiveList<T>
     /// <param name="items">The array of items to add to the collection. The collection will contain these items after the operation
     /// completes.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void UpdateTrackingCollection(ObservableCollection<T> target, T[] items)
-    {
-        target.Clear();
-        foreach (var item in items)
-        {
-            target.Add(item);
-        }
-    }
+    private static void UpdateTrackingCollection(RangeObservableCollection target, T[] items) => target.ReplaceAll(items);
 
     /// <summary>
     /// Extracts items from a cache notification.
@@ -1060,6 +1076,7 @@ public class ReactiveList<T> : IReactiveList<T>
     /// called directly in normal application code.</remarks>
     private void InitializeNonSerializedFields()
     {
+        _lock = new();
         _cleanUp = [];
         _observableItems = new(_internalList);
         _itemsAddedCollection = [];
@@ -1349,4 +1366,94 @@ public class ReactiveList<T> : IReactiveList<T>
 
         // Always emit to pipeline - internal subscription needs events for tracking collections
         _streamPipeline?.OnNext(new CacheNotify<T>(action, item, batch, currentIndex, previousIndex, previous));
+
+    private sealed class RangeObservableCollection : ObservableCollection<T>
+    {
+        public RangeObservableCollection()
+        {
+        }
+
+        public RangeObservableCollection(IEnumerable<T> items)
+            : base(items.ToList())
+        {
+        }
+
+        public void AddRange(IReadOnlyList<T> items)
+        {
+            if (items.Count == 0)
+            {
+                return;
+            }
+
+            CheckReentrancy();
+            EnsureCapacity(Items.Count + items.Count);
+            for (var i = 0; i < items.Count; i++)
+            {
+                Items.Add(items[i]);
+            }
+
+            RaiseReset();
+        }
+
+        public void InsertRange(int index, IReadOnlyList<T> items)
+        {
+            if (items.Count == 0)
+            {
+                return;
+            }
+
+            CheckReentrancy();
+            EnsureCapacity(Items.Count + items.Count);
+            for (var i = 0; i < items.Count; i++)
+            {
+                Items.Insert(index + i, items[i]);
+            }
+
+            RaiseReset();
+        }
+
+        public void RemoveRange(int index, int count)
+        {
+            if (count == 0)
+            {
+                return;
+            }
+
+            CheckReentrancy();
+            for (var i = 0; i < count; i++)
+            {
+                Items.RemoveAt(index);
+            }
+
+            RaiseReset();
+        }
+
+        public void ReplaceAll(IReadOnlyList<T> items)
+        {
+            CheckReentrancy();
+            Items.Clear();
+            EnsureCapacity(items.Count);
+            for (var i = 0; i < items.Count; i++)
+            {
+                Items.Add(items[i]);
+            }
+
+            RaiseReset();
+        }
+
+        private void RaiseReset()
+        {
+            OnPropertyChanged(new PropertyChangedEventArgs(nameof(Count)));
+            OnPropertyChanged(new PropertyChangedEventArgs(ItemArray));
+            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+
+        private void EnsureCapacity(int capacity)
+        {
+            if (Items is List<T> list && list.Capacity < capacity)
+            {
+                list.Capacity = capacity;
+            }
+        }
+    }
 }

--- a/src/ReactiveList/Core/SecondaryIndex.cs
+++ b/src/ReactiveList/Core/SecondaryIndex.cs
@@ -33,6 +33,13 @@ public class SecondaryIndex<T, TKey>(Func<T, TKey> selector) : ISecondaryIndex<T
         var key = selector(item);
         var s = GetShardIndex(key);
 
+#if NETFRAMEWORK
+        var set = _shards[s].GetOrAdd(key, _ => []);
+        lock (set)
+        {
+            set.Add(item);
+        }
+#else
         _shards[s].AddOrUpdate(
             key,
             addValueFactory: static (_, newItem) => [newItem],
@@ -46,6 +53,7 @@ public class SecondaryIndex<T, TKey>(Func<T, TKey> selector) : ISecondaryIndex<T
                 return set;
             },
             factoryArgument: item);
+#endif
     }
 
     /// <summary>

--- a/src/ReactiveList/Internal/ArrayPoolClearHelper.cs
+++ b/src/ReactiveList/Internal/ArrayPoolClearHelper.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace CP.Reactive.Internal;
+
+/// <summary>
+/// Provides target-framework-compatible array-pool clearing decisions.
+/// </summary>
+internal static class ArrayPoolClearHelper
+{
+    /// <summary>
+    /// Determines whether pooled arrays for <typeparamref name="T"/> should be cleared before return.
+    /// </summary>
+    /// <typeparam name="T">The array element type.</typeparam>
+    /// <returns><see langword="true"/> when clearing is required; otherwise, <see langword="false"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsReferenceOrContainsReferences<T>()
+    {
+#if NETFRAMEWORK
+        return !typeof(T).IsValueType;
+#else
+        return RuntimeHelpers.IsReferenceOrContainsReferences<T>();
+#endif
+    }
+}

--- a/src/ReactiveList/Internal/BatchChangeTracker.cs
+++ b/src/ReactiveList/Internal/BatchChangeTracker.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
 using System.Buffers;
 using System.Runtime.CompilerServices;
@@ -74,13 +74,13 @@ internal struct BatchChangeTracker<T> : IDisposable
     {
         if (_addedItems != null)
         {
-            ArrayPool<T>.Shared.Return(_addedItems, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+            ArrayPool<T>.Shared.Return(_addedItems, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
             _addedItems = null;
         }
 
         if (_removedItems != null)
         {
-            ArrayPool<T>.Shared.Return(_removedItems, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+            ArrayPool<T>.Shared.Return(_removedItems, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
             _removedItems = null;
         }
 
@@ -93,7 +93,7 @@ internal struct BatchChangeTracker<T> : IDisposable
     {
         var newArray = ArrayPool<T>.Shared.Rent(_addedItems!.Length * 2);
         _addedItems.AsSpan(0, _addedCount).CopyTo(newArray);
-        ArrayPool<T>.Shared.Return(_addedItems, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+        ArrayPool<T>.Shared.Return(_addedItems, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
         _addedItems = newArray;
     }
 
@@ -102,7 +102,7 @@ internal struct BatchChangeTracker<T> : IDisposable
     {
         var newArray = ArrayPool<T>.Shared.Rent(_removedItems!.Length * 2);
         _removedItems.AsSpan(0, _removedCount).CopyTo(newArray);
-        ArrayPool<T>.Shared.Return(_removedItems, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+        ArrayPool<T>.Shared.Return(_removedItems, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
         _removedItems = newArray;
     }
 }

--- a/src/ReactiveList/Internal/BitOperationsCompat.cs
+++ b/src/ReactiveList/Internal/BitOperationsCompat.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace CP.Reactive.Internal;
+
+/// <summary>
+/// Provides bit operations used by pooled collection sizing.
+/// </summary>
+internal static class BitOperationsCompat
+{
+    /// <summary>
+    /// Returns the integer base-2 logarithm of a non-zero unsigned value.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <returns>The integer base-2 logarithm.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Log2(uint value)
+    {
+#if NETFRAMEWORK
+        var result = 0;
+        while ((value >>= 1) != 0)
+        {
+            result++;
+        }
+
+        return result;
+#else
+        return System.Numerics.BitOperations.Log2(value);
+#endif
+    }
+
+    /// <summary>
+    /// Rounds a value up to the next power of two.
+    /// </summary>
+    /// <param name="value">The value to round.</param>
+    /// <returns>The rounded power-of-two value.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint RoundUpToPowerOf2(uint value)
+    {
+#if NETFRAMEWORK
+        if (value <= 1)
+        {
+            return 1;
+        }
+
+        value--;
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        return value + 1;
+#else
+        return System.Numerics.BitOperations.RoundUpToPowerOf2(value);
+#endif
+    }
+}

--- a/src/ReactiveList/Internal/CallerArgumentExpressionAttribute.cs
+++ b/src/ReactiveList/Internal/CallerArgumentExpressionAttribute.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Indicates that a parameter captures the expression passed for another parameter.
+/// </summary>
+/// <param name="parameterName">The source parameter name.</param>
+[AttributeUsage(AttributeTargets.Parameter)]
+internal sealed class CallerArgumentExpressionAttribute(string parameterName) : Attribute
+{
+    /// <summary>
+    /// Gets the source parameter name.
+    /// </summary>
+    public string ParameterName { get; } = parameterName;
+}
+#endif

--- a/src/ReactiveList/Internal/ChangeToken.cs
+++ b/src/ReactiveList/Internal/ChangeToken.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
 using System.Runtime.CompilerServices;
 

--- a/src/ReactiveList/Internal/EnumerablePolyfills.cs
+++ b/src/ReactiveList/Internal/EnumerablePolyfills.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NET462
+using System.Collections.Generic;
+
+namespace System.Linq;
+
+/// <summary>
+/// Provides LINQ helpers missing on .NET Framework.
+/// </summary>
+internal static class EnumerablePolyfills
+{
+    /// <summary>
+    /// Creates a hash set from a sequence.
+    /// </summary>
+    /// <typeparam name="TSource">The element type.</typeparam>
+    /// <param name="source">The source sequence.</param>
+    /// <returns>A hash set containing the source elements.</returns>
+    public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> source) => new(source);
+}
+#endif

--- a/src/ReactiveList/Internal/IsExternalInit.cs
+++ b/src/ReactiveList/Internal/IsExternalInit.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Reserved for compiler support.
+/// </summary>
+internal static class IsExternalInit
+{
+}
+#endif

--- a/src/ReactiveList/Internal/MaybeNullWhenAttribute.cs
+++ b/src/ReactiveList/Internal/MaybeNullWhenAttribute.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Specifies that an output may be null when the method returns the specified value.
+/// </summary>
+/// <param name="returnValue">The return value condition.</param>
+[AttributeUsage(AttributeTargets.Parameter)]
+internal sealed class MaybeNullWhenAttribute(bool returnValue) : Attribute
+{
+    /// <summary>
+    /// Gets a value indicating whether the attribute condition applies on true returns.
+    /// </summary>
+    public bool ReturnValue { get; } = returnValue;
+}
+#endif

--- a/src/ReactiveList/Internal/PooledBuffer.cs
+++ b/src/ReactiveList/Internal/PooledBuffer.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
 using System.Buffers;
 using System.Runtime.CompilerServices;
@@ -43,7 +43,7 @@ internal sealed class PooledBuffer<T>(T[] buffer, int length) : IDisposable
     {
         if (buffer != null)
         {
-            ArrayPool<T>.Shared.Return(buffer, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+            ArrayPool<T>.Shared.Return(buffer, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
             buffer = null!;
         }
     }

--- a/src/ReactiveList/Internal/ShardHash.cs
+++ b/src/ReactiveList/Internal/ShardHash.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
 using System.Runtime.CompilerServices;
 
@@ -42,6 +42,6 @@ internal static class ShardHash
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int BitCount(int n) => System.Numerics.BitOperations.Log2((uint)n);
+    private static int BitCount(int n) => CP.Reactive.Internal.BitOperationsCompat.Log2((uint)n);
 }
 #endif

--- a/src/ReactiveList/Internal/SkipLocalsInitAttribute.cs
+++ b/src/ReactiveList/Internal/SkipLocalsInitAttribute.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if NETFRAMEWORK
+namespace System.Runtime.CompilerServices;
+
+/// <summary>
+/// Indicates that local variables should not be zero-initialized.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Module)]
+internal sealed class SkipLocalsInitAttribute : Attribute
+{
+}
+#endif

--- a/src/ReactiveList/Internal/ThrowHelper.cs
+++ b/src/ReactiveList/Internal/ThrowHelper.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace CP.Reactive.Internal;
+
+/// <summary>
+/// Provides target-framework-compatible guard helpers.
+/// </summary>
+internal static class ThrowHelper
+{
+    /// <summary>
+    /// Throws when the supplied argument is null.
+    /// </summary>
+    /// <typeparam name="T">The argument type.</typeparam>
+    /// <param name="argument">The argument value.</param>
+    /// <param name="paramName">The parameter name, supplied by the compiler.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNull<T>(
+        T? argument,
+        [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        where T : class
+    {
+#if NETFRAMEWORK
+        if (argument is null)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+#else
+        ArgumentNullException.ThrowIfNull(argument, paramName);
+#endif
+    }
+}

--- a/src/ReactiveList/Internal/ValueBuffer.cs
+++ b/src/ReactiveList/Internal/ValueBuffer.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
 using System.Buffers;
 using System.Runtime.CompilerServices;
@@ -39,7 +39,7 @@ internal ref struct ValueBuffer<T>
     /// </summary>
     public readonly ReadOnlySpan<T> Span => _rentedArray != null
         ? _rentedArray.AsSpan(0, _count)
-        : _stackBuffer[.._count];
+        : _stackBuffer.Slice(0, _count);
 
     /// <summary>
     /// Adds an item to the buffer, growing if necessary.
@@ -79,7 +79,7 @@ internal ref struct ValueBuffer<T>
     {
         if (_rentedArray != null)
         {
-            ArrayPool<T>.Shared.Return(_rentedArray, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+            ArrayPool<T>.Shared.Return(_rentedArray, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
             _rentedArray = null;
         }
     }
@@ -89,7 +89,7 @@ internal ref struct ValueBuffer<T>
     {
         var newCapacity = _stackBuffer.Length * 2;
         _rentedArray = ArrayPool<T>.Shared.Rent(newCapacity);
-        _stackBuffer[.._count].CopyTo(_rentedArray);
+        _stackBuffer.Slice(0, _count).CopyTo(_rentedArray);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -98,7 +98,7 @@ internal ref struct ValueBuffer<T>
         var newCapacity = _rentedArray!.Length * 2;
         var newArray = ArrayPool<T>.Shared.Rent(newCapacity);
         _rentedArray.AsSpan(0, _count).CopyTo(newArray);
-        ArrayPool<T>.Shared.Return(_rentedArray, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<T>());
+        ArrayPool<T>.Shared.Return(_rentedArray, clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
         _rentedArray = newArray;
     }
 }

--- a/src/ReactiveList/QuaternaryExtensions.cs
+++ b/src/ReactiveList/QuaternaryExtensions.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) Chris Pulman. All rights reserved.
+// Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -40,8 +40,8 @@ public static class QuaternaryExtensions
         where T : notnull
         where TKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
 
         // Get initial snapshot from the secondary index
         var snapshot = list.GetItemsBySecondaryIndex(indexName, key);
@@ -70,9 +70,9 @@ public static class QuaternaryExtensions
         where T : notnull
         where TKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(indexName);
-        ArgumentNullException.ThrowIfNull(keys);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(keys);
 
         // Get initial snapshot from the secondary index for all keys
         var snapshot = keys.SelectMany(key => list.GetItemsBySecondaryIndex(indexName, key));
@@ -106,9 +106,9 @@ public static class QuaternaryExtensions
         where T : notnull
         where TKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(indexName);
-        ArgumentNullException.ThrowIfNull(keysObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(keysObservable);
 
         return new DynamicSecondaryIndexReactiveView<T, TKey>(list, indexName, keysObservable, scheduler, TimeSpan.FromMilliseconds(throttleMs));
     }
@@ -130,20 +130,20 @@ public static class QuaternaryExtensions
         where T : notnull
         where TKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(stream);
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(stream);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
 
         return stream.Select(notification =>
         {
-            // Get the current set of items matching the key from the secondary index
-            var matchingItems = list.GetItemsBySecondaryIndex(indexName, key).Where(x => x != null).ToHashSet()!;
+            bool Matches(T item) => list.ItemMatchesSecondaryIndex(indexName, item, key);
 
             return notification.Action switch
             {
-                CacheAction.Added when notification.Item != null && matchingItems.Contains(notification.Item) => notification,
-                CacheAction.Removed when notification.Item != null && matchingItems.Contains(notification.Item) => notification,
-                CacheAction.BatchOperation when notification.Batch != null => ReactiveListExtensions.FilterBatch(notification, matchingItems!),
+                CacheAction.Added when notification.Item != null && Matches(notification.Item) => notification,
+                CacheAction.Removed when notification.Item != null && Matches(notification.Item) => notification,
+                CacheAction.BatchAdded or CacheAction.BatchRemoved or CacheAction.BatchOperation when notification.Batch != null =>
+                    ReactiveListExtensions.FilterBatchByPredicate(notification, Matches),
                 CacheAction.Cleared => notification,
                 _ => null
             };
@@ -168,21 +168,21 @@ public static class QuaternaryExtensions
         where T : notnull
         where TKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(stream);
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(indexName);
-        ArgumentNullException.ThrowIfNull(keys);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(stream);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(keys);
 
         return stream.Select(notification =>
         {
-            // Get the current set of items matching all keys from the secondary index
-            var matchingItems = keys.SelectMany(key => list.GetItemsBySecondaryIndex(indexName, key)).Where(x => x != null).ToHashSet()!;
+            bool Matches(T item) => keys.Any(key => list.ItemMatchesSecondaryIndex(indexName, item, key));
 
             return notification.Action switch
             {
-                CacheAction.Added when notification.Item != null && matchingItems.Contains(notification.Item) => notification,
-                CacheAction.Removed when notification.Item != null && matchingItems.Contains(notification.Item) => notification,
-                CacheAction.BatchOperation when notification.Batch != null => ReactiveListExtensions.FilterBatch(notification, matchingItems!),
+                CacheAction.Added when notification.Item != null && Matches(notification.Item) => notification,
+                CacheAction.Removed when notification.Item != null && Matches(notification.Item) => notification,
+                CacheAction.BatchAdded or CacheAction.BatchRemoved or CacheAction.BatchOperation when notification.Batch != null =>
+                    ReactiveListExtensions.FilterBatchByPredicate(notification, Matches),
                 CacheAction.Cleared => notification,
                 _ => null
             };
@@ -209,8 +209,8 @@ public static class QuaternaryExtensions
         where TKey : notnull
         where TIndexKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(dict);
-        ArgumentNullException.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(dict);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
 
         // Get initial snapshot from the secondary index - map values back to key-value pairs
         var matchingValues = dict.GetValuesBySecondaryIndex(indexName, indexKey).ToHashSet();
@@ -245,9 +245,9 @@ public static class QuaternaryExtensions
         where TKey : notnull
         where TIndexKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(dict);
-        ArgumentNullException.ThrowIfNull(indexName);
-        ArgumentNullException.ThrowIfNull(indexKeys);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(dict);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexKeys);
 
         // Get initial snapshot from the secondary index for all keys
         var matchingValues = indexKeys.SelectMany(k => dict.GetValuesBySecondaryIndex(indexName, k)).ToHashSet();
@@ -283,9 +283,9 @@ public static class QuaternaryExtensions
         where TKey : notnull
         where TIndexKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(dict);
-        ArgumentNullException.ThrowIfNull(indexName);
-        ArgumentNullException.ThrowIfNull(keysObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(dict);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(keysObservable);
 
         return new DynamicSecondaryIndexDictionaryReactiveView<TKey, TValue, TIndexKey>(dict, indexName, keysObservable, scheduler, TimeSpan.FromMilliseconds(throttleMs));
     }
@@ -307,21 +307,21 @@ public static class QuaternaryExtensions
         where TKey : notnull
         where TIndexKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(stream);
-        ArgumentNullException.ThrowIfNull(dict);
-        ArgumentNullException.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(stream);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(dict);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
 
         return stream.Select(notification =>
         {
-            // Get the current set of values matching the key from the secondary index
-            var matchingValues = new HashSet<TValue>(dict.GetValuesBySecondaryIndex(indexName, indexKey));
+            bool Matches(KeyValuePair<TKey, TValue> item) =>
+                item.Value != null && dict.ValueMatchesSecondaryIndex(indexName, item.Value, indexKey);
 
             return notification.Action switch
             {
-                CacheAction.Added when notification.Item.Value != null && matchingValues.Contains(notification.Item.Value) => notification,
-                CacheAction.Removed when notification.Item.Value != null && matchingValues.Contains(notification.Item.Value) => notification,
+                CacheAction.Added when Matches(notification.Item) => notification,
+                CacheAction.Removed when Matches(notification.Item) => notification,
                 CacheAction.BatchAdded or CacheAction.BatchRemoved or CacheAction.BatchOperation when notification.Batch != null =>
-                    ReactiveListExtensions.FilterBatch(notification, dict.Where(kvp => matchingValues.Contains(kvp.Value)).Select(kvp => new KeyValuePair<TKey, TValue>(kvp.Key, kvp.Value!)).ToHashSet()),
+                    ReactiveListExtensions.FilterBatchByPredicate(notification, Matches),
                 CacheAction.Cleared => notification,
                 _ => null
             };
@@ -347,22 +347,22 @@ public static class QuaternaryExtensions
         where TKey : notnull
         where TIndexKey : notnull
     {
-        ArgumentNullException.ThrowIfNull(stream);
-        ArgumentNullException.ThrowIfNull(dict);
-        ArgumentNullException.ThrowIfNull(indexName);
-        ArgumentNullException.ThrowIfNull(indexKeys);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(stream);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(dict);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexName);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(indexKeys);
 
         return stream.Select(notification =>
         {
-            // Get the current set of values matching all keys from the secondary index
-            var matchingValues = new HashSet<TValue>(indexKeys.SelectMany(key => dict.GetValuesBySecondaryIndex(indexName, key)));
+            bool Matches(KeyValuePair<TKey, TValue> item) =>
+                item.Value != null && indexKeys.Any(key => dict.ValueMatchesSecondaryIndex(indexName, item.Value, key));
 
             return notification.Action switch
             {
-                CacheAction.Added when notification.Item.Value != null && matchingValues.Contains(notification.Item.Value) => notification,
-                CacheAction.Removed when notification.Item.Value != null && matchingValues.Contains(notification.Item.Value) => notification,
+                CacheAction.Added when Matches(notification.Item) => notification,
+                CacheAction.Removed when Matches(notification.Item) => notification,
                 CacheAction.BatchAdded or CacheAction.BatchRemoved or CacheAction.BatchOperation when notification.Batch != null =>
-                    ReactiveListExtensions.FilterBatch(notification, dict.Where(kvp => matchingValues.Contains(kvp.Value)).Select(kvp => new KeyValuePair<TKey, TValue>(kvp.Key, kvp.Value!)).ToHashSet()),
+                    ReactiveListExtensions.FilterBatchByPredicate(notification, Matches),
                 CacheAction.Cleared => notification,
                 _ => null
             };

--- a/src/ReactiveList/ReactiveList.csproj
+++ b/src/ReactiveList/ReactiveList.csproj
@@ -5,12 +5,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>CP.Reactive</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
     <!-- Required for SkipLocalsInit attribute to reduce zero-initialization overhead -->
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,10 +19,6 @@
 
   <!-- System.Buffers and System.Memory for .NET Framework -->
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="Polyfill" Version="9.24.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Buffers" Version="4.6.1" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Threading.Channels" Version="10.0.7" />

--- a/src/ReactiveList/ReactiveListExtensions.cs
+++ b/src/ReactiveList/ReactiveListExtensions.cs
@@ -30,8 +30,8 @@ public static class ReactiveListExtensions
         Func<Change<T>, bool> predicate)
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(source);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(predicate);
 #else
         if (source == null)
         {
@@ -117,8 +117,8 @@ public static class ReactiveListExtensions
         Func<T, TResult> selector)
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(selector);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(source);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(selector);
 #else
         if (source == null)
         {
@@ -168,8 +168,8 @@ public static class ReactiveListExtensions
         Func<Change<TSource>, TResult> selector)
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(selector);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(source);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(selector);
 #else
         if (source == null)
         {
@@ -254,8 +254,8 @@ public static class ReactiveListExtensions
         where TKey : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-        ArgumentNullException.ThrowIfNull(filterObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(stream);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(filterObservable);
 #else
         if (stream == null)
         {
@@ -296,8 +296,8 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-        ArgumentNullException.ThrowIfNull(filterObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(stream);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(filterObservable);
 #else
         if (stream == null)
         {
@@ -340,8 +340,8 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(filter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(filter);
 #else
         if (list == null)
         {
@@ -388,8 +388,8 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(filterObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(filterObservable);
 #else
         if (list == null)
         {
@@ -428,9 +428,9 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(queryObservable);
-        ArgumentNullException.ThrowIfNull(filter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(queryObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(filter);
 #else
         if (list == null)
         {
@@ -471,8 +471,8 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(filterObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(filterObservable);
 #else
         if (list == null)
         {
@@ -506,7 +506,7 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
 #else
         if (list == null)
         {
@@ -539,7 +539,7 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
 #else
         if (list == null)
         {
@@ -569,8 +569,8 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(comparer);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(comparer);
 #else
         if (list == null)
         {
@@ -606,8 +606,8 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(keySelector);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(keySelector);
 #else
         if (list == null)
         {
@@ -708,8 +708,8 @@ public static class ReactiveListExtensions
         where TKey : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(list);
-        ArgumentNullException.ThrowIfNull(keySelector);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(list);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(keySelector);
 #else
         if (list == null)
         {
@@ -872,8 +872,8 @@ public static class ReactiveListExtensions
         where T : notnull
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(property);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(source);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(property);
 #else
         if (source == null)
         {

--- a/src/ReactiveList/Views/DynamicFilteredReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicFilteredReactiveView.cs
@@ -43,7 +43,7 @@ where T : notnull
     {
         _source = source ?? throw new ArgumentNullException(nameof(source));
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(filterObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(filterObservable);
 #else
         if (filterObservable == null)
         {
@@ -132,7 +132,7 @@ where T : notnull
     public DynamicFilteredReactiveView<T> ToProperty(Action<ReadOnlyObservableCollection<T>> propertySetter)
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(propertySetter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(propertySetter);
 #else
         if (propertySetter == null)
         {

--- a/src/ReactiveList/Views/DynamicReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicReactiveView.cs
@@ -57,9 +57,9 @@ where T : notnull
 #endif
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(filterObservable);
-        ArgumentNullException.ThrowIfNull(scheduler);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(source);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(filterObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(scheduler);
 #else
         if (source == null)
         {
@@ -133,7 +133,7 @@ where T : notnull
     public DynamicReactiveView<T> ToProperty(Action<ReadOnlyObservableCollection<T>> propertySetter)
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(propertySetter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(propertySetter);
 #else
         if (propertySetter == null)
         {

--- a/src/ReactiveList/Views/DynamicSecondaryIndexDictionaryReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicSecondaryIndexDictionaryReactiveView.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -52,7 +52,7 @@ where TIndexKey : notnull
     {
         _source = source ?? throw new ArgumentNullException(nameof(source));
         _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
-        ArgumentNullException.ThrowIfNull(keysObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(keysObservable);
 
         _filteredItems = [];
         Items = new ReadOnlyObservableCollection<KeyValuePair<TKey, TValue>>(_filteredItems);
@@ -138,7 +138,7 @@ where TIndexKey : notnull
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="propertySetter"/> is null.</exception>
     public DynamicSecondaryIndexDictionaryReactiveView<TKey, TValue, TIndexKey> ToProperty(Action<ReadOnlyObservableCollection<KeyValuePair<TKey, TValue>>> propertySetter)
     {
-        ArgumentNullException.ThrowIfNull(propertySetter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(propertySetter);
         propertySetter(Items);
         return this;
     }

--- a/src/ReactiveList/Views/DynamicSecondaryIndexReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicSecondaryIndexReactiveView.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -50,7 +50,7 @@ where TKey : notnull
     {
         _source = source ?? throw new ArgumentNullException(nameof(source));
         _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
-        ArgumentNullException.ThrowIfNull(keysObservable);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(keysObservable);
 
         _filteredItems = [];
         Items = new ReadOnlyObservableCollection<T>(_filteredItems);
@@ -136,7 +136,7 @@ where TKey : notnull
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="propertySetter"/> is null.</exception>
     public DynamicSecondaryIndexReactiveView<T, TKey> ToProperty(Action<ReadOnlyObservableCollection<T>> propertySetter)
     {
-        ArgumentNullException.ThrowIfNull(propertySetter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(propertySetter);
         propertySetter(Items);
         return this;
     }

--- a/src/ReactiveList/Views/FilteredReactiveView.cs
+++ b/src/ReactiveList/Views/FilteredReactiveView.cs
@@ -114,7 +114,7 @@ where T : notnull
     public FilteredReactiveView<T> ToProperty(Action<ReadOnlyObservableCollection<T>> propertySetter)
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(propertySetter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(propertySetter);
 #else
         if (propertySetter == null)
         {

--- a/src/ReactiveList/Views/GroupedReactiveView.cs
+++ b/src/ReactiveList/Views/GroupedReactiveView.cs
@@ -158,7 +158,7 @@ where TKey : notnull
     public GroupedReactiveView<T, TKey> ToProperty(Action<ReadOnlyObservableCollection<ReactiveGroup<TKey, T>>> propertySetter)
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(propertySetter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(propertySetter);
 #else
         if (propertySetter == null)
         {

--- a/src/ReactiveList/Views/SecondaryIndexReactiveView.cs
+++ b/src/ReactiveList/Views/SecondaryIndexReactiveView.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Chris Pulman. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER || NETFRAMEWORK
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -120,7 +120,7 @@ where TIndexKey : notnull
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="propertySetter"/> is null.</exception>
     public SecondaryIndexReactiveView<TKey, TValue, TIndexKey> ToProperty(Action<ReadOnlyObservableCollection<TValue>> propertySetter)
     {
-        ArgumentNullException.ThrowIfNull(propertySetter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(propertySetter);
         propertySetter(Items);
         return this;
     }
@@ -168,18 +168,7 @@ where TIndexKey : notnull
                 case CacheAction.Updated:
                     if (notification.Item.Value != null)
                     {
-                        // Check if the updated item's index key changed
-                        var wasInView = _filteredItems.Contains(notification.Item.Value);
-                        var shouldBeInView = _source.ValueMatchesSecondaryIndex(_indexName, notification.Item.Value, _indexKey);
-
-                        if (wasInView && !shouldBeInView)
-                        {
-                            _filteredItems.Remove(notification.Item.Value);
-                        }
-                        else if (!wasInView && shouldBeInView)
-                        {
-                            _filteredItems.Add(notification.Item.Value);
-                        }
+                        RebuildView();
                     }
 
                     break;

--- a/src/ReactiveList/Views/SortedReactiveView.cs
+++ b/src/ReactiveList/Views/SortedReactiveView.cs
@@ -122,7 +122,7 @@ where T : notnull
     public SortedReactiveView<T> ToProperty(Action<ReadOnlyObservableCollection<T>> propertySetter)
     {
 #if NET8_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(propertySetter);
+        CP.Reactive.Internal.ThrowHelper.ThrowIfNull(propertySetter);
 #else
         if (propertySetter == null)
         {


### PR DESCRIPTION
## Summary
- Add `net462`, `net481`, and the updated Windows TFMs to the solution and package targets.
- Migrate the test project to TUnit and add broad coverage scaffolding to drive toward full code coverage.
- Update the README with fuller API documentation, examples, and refreshed benchmark guidance.
- Optimize quaternary collection paths and supporting internals to reduce allocations and improve bulk-add performance.

## Testing
- `dotnet build .\src\ReactiveList.sln --configuration Release --no-restore`
- TUnit test runs passed on `net462`, `net48`, `net481`, `net8.0-windows10.0.17763.0`, and `net10.0-windows10.0.17763.0`.
- Focused benchmark runs were executed for `QuaternaryList<T>` and `QuaternaryDictionary<TKey,TValue>` AddRange workloads.