### PR TITLE
Improve notifications, batching and non-blocking views

### DIFF
--- a/src/ReactiveList.Benchmarks/DynamicDataParityBenchmarks.cs
+++ b/src/ReactiveList.Benchmarks/DynamicDataParityBenchmarks.cs
@@ -1,0 +1,126 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Reactive.Linq;
+using BenchmarkDotNet.Attributes;
+using CP.Reactive;
+using CP.Reactive.Collections;
+using DynamicData;
+using DynamicData.Binding;
+
+namespace ReactiveList.Benchmarks;
+
+[MemoryDiagnoser]
+public class DynamicDataParityBenchmarks
+{
+    [Params(1_000, 10_000)]
+    public int Count { get; set; }
+
+    private int[] _data = [];
+
+    [GlobalSetup]
+    public void Setup() => _data = Enumerable.Range(0, Count).ToArray();
+
+    [Benchmark]
+    public int ReactiveList_Connect_Preloaded_InitialSnapshot()
+    {
+        using var list = new ReactiveList<int>(_data);
+        var total = 0;
+        using var subscription = list.Connect().Subscribe(changes => total += changes.Count);
+        return total;
+    }
+
+    [Benchmark]
+    public int SourceList_Connect_Preloaded_InitialSnapshot()
+    {
+        using var list = new SourceList<int>();
+        list.AddRange(_data);
+        var total = 0;
+        using var subscription = list.Connect().Subscribe(changes => total += changes.TotalChanges);
+        return total;
+    }
+
+    [Benchmark]
+    public int ReactiveList_FilterTransformSort()
+    {
+        using var list = new ReactiveList<int>();
+        var total = 0;
+        var pipeline = CP.Reactive.ReactiveListExtensions.SortBy<int, int>(
+            list.Connect()
+                .WhereChanges(static change => change.Current % 2 == 0)
+                .SelectChanges(static (int item) => item * 2),
+            static item => item);
+        using var subscription = pipeline.Subscribe(changes => total += changes.Count);
+
+        list.AddRange(_data);
+        return total;
+    }
+
+    [Benchmark]
+    public int SourceList_FilterTransformSortBind()
+    {
+        using var list = new SourceList<int>();
+        using var subscription = list.Connect()
+            .Filter(static item => item % 2 == 0)
+            .Transform(static item => item * 2)
+            .Sort(SortExpressionComparer<int>.Ascending(static item => item))
+            .Bind(out ReadOnlyObservableCollection<int> bound)
+            .Subscribe();
+
+        list.AddRange(_data);
+        return bound.Count;
+    }
+
+    [Benchmark]
+    public int ReactiveList_INCC_AddRange_WithItemsSubscriber()
+    {
+        using var list = new ReactiveList<int>();
+        var events = 0;
+        ((INotifyCollectionChanged)list.Items).CollectionChanged += (_, _) => events++;
+
+        list.AddRange(_data);
+        return events;
+    }
+
+    [Benchmark]
+    public int SourceList_INCC_AddRange_WithBoundSubscriber()
+    {
+        using var list = new SourceList<int>();
+        using var subscription = list.Connect()
+            .Bind(out ReadOnlyObservableCollection<int> bound)
+            .Subscribe();
+        var events = 0;
+        ((INotifyCollectionChanged)bound).CollectionChanged += (_, _) => events++;
+
+        list.AddRange(_data);
+        return events;
+    }
+
+    [Benchmark]
+    public int QuaternaryList_Stream_AddRange_DeliveryWait()
+    {
+        using var list = new QuaternaryList<int>();
+        using var delivered = new ManualResetEventSlim();
+        var events = 0;
+        using var subscription = list.Stream.Subscribe(notification =>
+        {
+            events++;
+            notification.Batch?.Dispose();
+            delivered.Set();
+        });
+
+        list.AddRange(_data);
+        delivered.Wait(TimeSpan.FromSeconds(1));
+        return events;
+    }
+
+    [Benchmark]
+    public int SourceList_Stream_AddRange_Delivery()
+    {
+        using var list = new SourceList<int>();
+        var events = 0;
+        using var subscription = list.Connect().Subscribe(_ => events++);
+
+        list.AddRange(_data);
+        return events;
+    }
+}

--- a/src/ReactiveList.Test/ReactiveListConnectTests.cs
+++ b/src/ReactiveList.Test/ReactiveListConnectTests.cs
@@ -34,6 +34,23 @@ public class ReactiveListConnectTests
     }
 
     /// <summary>
+    /// Connect emits the current snapshot for preloaded sources.
+    /// </summary>
+    [Test]
+    public void Connect_EmitsInitialSnapshot_WhenSourceHasItems()
+    {
+        using var list = new ReactiveList<int>([1, 2, 3]);
+        var receivedChanges = new List<ChangeSet<int>>();
+
+        using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+
+        receivedChanges.Should().ContainSingle();
+        receivedChanges[0].Count.Should().Be(3);
+        receivedChanges[0].Adds.Should().Be(3);
+        receivedChanges[0].Select(change => change.Current).Should().Equal(1, 2, 3);
+    }
+
+    /// <summary>
     /// Connect emits add changes when items are added.
     /// </summary>
     [Test]
@@ -85,6 +102,7 @@ public class ReactiveListConnectTests
         using var list = new ReactiveList<int>([1, 2, 3]);
         var receivedChanges = new List<ChangeSet<int>>();
         using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        receivedChanges.Clear();
 
         // Act
         list.Remove(2);
@@ -108,6 +126,7 @@ public class ReactiveListConnectTests
         using var list = new ReactiveList<int>([1, 2, 3]);
         var receivedChanges = new List<ChangeSet<int>>();
         using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        receivedChanges.Clear();
 
         // Act
         list.Clear();
@@ -131,6 +150,7 @@ public class ReactiveListConnectTests
         using var list = new ReactiveList<int>([1, 2, 3, 4, 5]);
         var receivedChanges = new List<ChangeSet<int>>();
         using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        receivedChanges.Clear();
 
         // Act
         list.Move(0, 4);
@@ -155,6 +175,7 @@ public class ReactiveListConnectTests
         using var list = new ReactiveList<int>([1, 2, 3]);
         var receivedChanges = new List<ChangeSet<int>>();
         using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        receivedChanges.Clear();
 
         // Act
         list.Update(2, 20);

--- a/src/ReactiveList.Test/ReactiveListNotificationComplianceTests.cs
+++ b/src/ReactiveList.Test/ReactiveListNotificationComplianceTests.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Chris Pulman. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using CP.Reactive.Collections;
+using CP.Reactive.Views;
+using FluentAssertions;
+using TUnit.Core;
+
+namespace ReactiveList.Test;
+
+/// <summary>
+/// Tests notification contracts used by UI binding and DynamicData-style pipelines.
+/// </summary>
+public class ReactiveListNotificationComplianceTests
+{
+    /// <summary>
+    /// Indexer replacement should be one replace notification and should not report a count change.
+    /// </summary>
+    [Test]
+    public void IndexerSet_ShouldEmitSingleReplaceAndNoCountPropertyChange()
+    {
+        using var list = new ReactiveList<int>([1, 2, 3]);
+        var collectionEvents = new List<NotifyCollectionChangedEventArgs>();
+        var propertyNames = new List<string?>();
+        list.CollectionChanged += (_, args) => collectionEvents.Add(args);
+        list.PropertyChanged += (_, args) => propertyNames.Add(args.PropertyName);
+
+        list[1] = 20;
+
+        list.Should().Equal(1, 20, 3);
+        collectionEvents.Should().ContainSingle();
+        collectionEvents[0].Action.Should().Be(NotifyCollectionChangedAction.Replace);
+        collectionEvents[0].OldItems!.Cast<int>().Should().Equal(2);
+        collectionEvents[0].NewItems!.Cast<int>().Should().Equal(20);
+        propertyNames.Should().Equal("Item[]");
+    }
+
+    /// <summary>
+    /// Bulk operations on the UI-facing Items collection should coalesce to one collection notification.
+    /// </summary>
+    [Test]
+    public void BulkOperations_ShouldRaiseSingleItemsCollectionChangedNotification()
+    {
+        using var list = new ReactiveList<int>();
+        var itemEvents = new List<NotifyCollectionChangedEventArgs>();
+        ((INotifyCollectionChanged)list.Items).CollectionChanged += (_, args) => itemEvents.Add(args);
+
+        var values = new[] { 1, 2, 3, 4 };
+        list.AddRange(values.AsSpan());
+
+        itemEvents.Should().ContainSingle();
+        itemEvents[0].Action.Should().Be(NotifyCollectionChangedAction.Reset);
+
+        itemEvents.Clear();
+        list.Remove(new[] { 1, 3 });
+        itemEvents.Should().ContainSingle();
+        itemEvents[0].Action.Should().Be(NotifyCollectionChangedAction.Reset);
+
+        itemEvents.Clear();
+        list.RemoveMany(static item => item > 0);
+        itemEvents.Should().ContainSingle();
+        itemEvents[0].Action.Should().Be(NotifyCollectionChangedAction.Reset);
+    }
+
+    /// <summary>
+    /// ReplaceAll to empty should not suppress tracking for the following notification.
+    /// </summary>
+    [Test]
+    public void ReplaceAllToEmpty_ShouldNotSuppressNextNotification()
+    {
+        using var list = new ReactiveList<string>(["seed"]);
+        var snapshots = new List<string[]>();
+        using var subscription = list.CurrentItems.Subscribe(items => snapshots.Add(items.ToArray()));
+
+        list.ReplaceAll(Array.Empty<string>());
+        list.Add("next");
+
+        list.ItemsAdded.Should().Equal("next");
+        list.ItemsChanged.Should().Equal("next");
+        snapshots.Last().Should().Equal("next");
+    }
+
+    /// <summary>
+    /// Dynamic views should not block construction when no initial filter has been published.
+    /// </summary>
+    [Test]
+    public void DynamicReactiveView_WithColdFilterSubject_ShouldConstructImmediately()
+    {
+        using var source = new ReactiveList<int>([1, 2, 3]);
+        using var filters = new Subject<Func<int, bool>>();
+
+        using var view = new DynamicReactiveView<int>(
+            source,
+            filters,
+            TimeSpan.Zero,
+            ImmediateScheduler.Instance);
+
+        view.Items.Should().Equal(1, 2, 3);
+        filters.OnNext(static item => item > 1);
+        view.Items.Should().Equal(2, 3);
+    }
+
+#if NET8_0_OR_GREATER || NETFRAMEWORK
+    /// <summary>
+    /// Dynamic secondary-index views should not block construction without an initial key emission.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task DynamicSecondaryIndexView_WithColdKeysSubject_ShouldConstructImmediately()
+    {
+        using var source = new QuaternaryList<IndexedItem>();
+        var north = new IndexedItem(1, "north");
+        source.Add(north);
+        source.AddIndex("region", static item => item.Region);
+        using var keys = new Subject<string[]>();
+
+        using var view = new DynamicSecondaryIndexReactiveView<IndexedItem, string>(
+            source,
+            "region",
+            keys,
+            ImmediateScheduler.Instance,
+            TimeSpan.Zero);
+
+        view.Items.Should().BeEmpty();
+        keys.OnNext(["north"]);
+        await Task.Delay(25);
+        view.Items.Should().ContainSingle().Which.Should().Be(north);
+    }
+
+    /// <summary>
+    /// Quaternary collections should raise INPC notifications for UI-bound count/indexer properties.
+    /// </summary>
+    [Test]
+    public void QuaternaryCollections_ShouldRaisePropertyChangedForMutations()
+    {
+        using var list = new QuaternaryList<int>();
+        var listProperties = new List<string?>();
+        ((INotifyPropertyChanged)list).PropertyChanged += (_, args) => listProperties.Add(args.PropertyName);
+
+        list.AddRange([1, 2, 3]);
+
+        listProperties.Should().Contain(nameof(list.Count));
+        listProperties.Should().Contain("Item[]");
+
+        using var dictionary = new QuaternaryDictionary<int, string>();
+        var dictionaryProperties = new List<string?>();
+        ((INotifyPropertyChanged)dictionary).PropertyChanged += (_, args) => dictionaryProperties.Add(args.PropertyName);
+
+        dictionary.AddRange([new KeyValuePair<int, string>(1, "one")]);
+
+        dictionaryProperties.Should().Contain(nameof(dictionary.Count));
+        dictionaryProperties.Should().Contain("Item[]");
+    }
+#endif
+
+    private sealed record IndexedItem(int Id, string Region);
+}

--- a/src/ReactiveList.Test/ReactiveListNotificationComplianceTests.cs
+++ b/src/ReactiveList.Test/ReactiveListNotificationComplianceTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Threading;
 using System.Threading.Tasks;
 using CP.Reactive.Collections;
 using CP.Reactive.Views;
@@ -159,6 +160,60 @@ public class ReactiveListNotificationComplianceTests
 
         dictionaryProperties.Should().Contain(nameof(dictionary.Count));
         dictionaryProperties.Should().Contain("Item[]");
+    }
+
+    /// <summary>
+    /// Optimized quaternary list range removal should preserve multiset semantics for duplicate values.
+    /// </summary>
+    [Test]
+    public void QuaternaryList_RemoveRange_ShouldRemoveOnlyRequestedDuplicateCount()
+    {
+        using var list = new QuaternaryList<int>();
+        list.AddRange([1, 1, 1, 2, 3]);
+
+        list.RemoveRange([1, 1, 4]);
+
+        list.Count.Should().Be(3);
+        list.ToArray().Should().BeEquivalentTo([1, 2, 3]);
+    }
+
+    /// <summary>
+    /// Dictionary range operations should keep count exact for overwrites and no-op removals.
+    /// </summary>
+    [Test]
+    public void QuaternaryDictionary_RangeOperations_ShouldMaintainCountAndSkipNoOpRemoveNotification()
+    {
+        using var dictionary = new QuaternaryDictionary<int, string>();
+        var notifications = 0;
+        using var received = new ManualResetEventSlim();
+        using var subscription = dictionary.Stream.Subscribe(_ =>
+        {
+            Interlocked.Increment(ref notifications);
+            received.Set();
+        });
+
+        dictionary.AddRange(
+        [
+            new KeyValuePair<int, string>(1, "one"),
+            new KeyValuePair<int, string>(1, "uno"),
+            new KeyValuePair<int, string>(2, "two")
+        ]);
+
+        dictionary.Count.Should().Be(2);
+        received.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
+        notifications.Should().Be(1);
+
+        received.Reset();
+        dictionary.RemoveKeys([99]);
+        dictionary.Count.Should().Be(2);
+        received.Wait(TimeSpan.FromMilliseconds(50)).Should().BeFalse();
+        notifications.Should().Be(1);
+
+        received.Reset();
+        dictionary.RemoveKeys([1]);
+        dictionary.Count.Should().Be(1);
+        received.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
+        notifications.Should().Be(2);
     }
 #endif
 

--- a/src/ReactiveList.Test/ReactiveListRemoveTests.cs
+++ b/src/ReactiveList.Test/ReactiveListRemoveTests.cs
@@ -439,6 +439,7 @@ public class ReactiveListRemoveTests
         using var fixture = new ReactiveList<int>([1, 2, 3, 4, 5]);
         var receivedChanges = new System.Collections.Generic.List<ChangeSet<int>>();
         using var subscription = fixture.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        receivedChanges.Clear();
 
         var removed = fixture.RemoveMany(x => x > 3);
 

--- a/src/ReactiveList/Collections/QuadList.cs
+++ b/src/ReactiveList/Collections/QuadList.cs
@@ -21,6 +21,7 @@ namespace CP.Reactive.Collections;
 /// <typeparam name="T">The type of elements in the list.</typeparam>
 [SkipLocalsInit]
 public sealed class QuadList<T> : IDisposable, IQuad<T>
+    where T : notnull
 {
     private const int MinimumSize = 16;
 
@@ -241,6 +242,54 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void AddAssumeCapacity(T item) => _items[_count++] = item;
+
+    internal int RemoveMatching(Dictionary<T, int> removeCounts, List<T>? removedItems)
+    {
+        var items = _items;
+        var count = _count;
+        var writeIndex = 0;
+        var removed = 0;
+
+        for (var readIndex = 0; readIndex < count; readIndex++)
+        {
+            var item = items[readIndex];
+            if (removeCounts.TryGetValue(item, out var remaining))
+            {
+                if (remaining == 1)
+                {
+                    removeCounts.Remove(item);
+                }
+                else
+                {
+                    removeCounts[item] = remaining - 1;
+                }
+
+                removedItems?.Add(item);
+                removed++;
+                continue;
+            }
+
+            if (writeIndex != readIndex)
+            {
+                items[writeIndex] = item;
+            }
+
+            writeIndex++;
+        }
+
+        if (removed == 0)
+        {
+            return 0;
+        }
+
+        if (CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>())
+        {
+            Array.Clear(items, writeIndex, removed);
+        }
+
+        _count = writeIndex;
+        return removed;
+    }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowIndexOutOfRange() => throw new IndexOutOfRangeException();

--- a/src/ReactiveList/Collections/QuaternaryBase.cs
+++ b/src/ReactiveList/Collections/QuaternaryBase.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #if NET8_0_OR_GREATER || NETFRAMEWORK
 
-using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
@@ -25,7 +25,7 @@ namespace CP.Reactive.Collections;
 /// <typeparam name="TItem">The type of items stored in the collection. Must be non-nullable.</typeparam>
 /// <typeparam name="TQuad">The type representing a quad (shard) within the collection. Must implement <see cref="IQuad{TItem}"/>.</typeparam>
 /// <typeparam name="TValue">The type used for secondary indexing within the collection.</typeparam>
-public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TItem>
+public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TItem>, INotifyPropertyChanged
     where TItem : notnull
     where TQuad : IQuad<TItem>, new()
 {
@@ -69,6 +69,9 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
         new TQuad()
     ];
 
+    private const string ItemArray = "Item[]";
+    private static readonly PropertyChangedEventArgs CountPropertyChangedEventArgs = new(nameof(Count));
+    private static readonly PropertyChangedEventArgs ItemArrayPropertyChangedEventArgs = new(ItemArray);
     private readonly SynchronizationContext? _syncContext;
     private Channel<CacheNotify<TItem>>? _eventChannel;
     private object? _eventGate;
@@ -110,6 +113,9 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
 
         remove => _collectionChanged -= value;
     }
+
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     /// <summary>
     /// Gets the total number of items contained in all quads.
@@ -250,6 +256,8 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     {
         // Increment version atomically for change tracking
         Interlocked.Increment(ref _version);
+        OnPropertyChanged(CountPropertyChangedEventArgs);
+        OnPropertyChanged(ItemArrayPropertyChangedEventArgs);
 
         // Fast path: skip channel write if no subscribers and no INCC
         if (!HasChangeObservers())
@@ -259,7 +267,10 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
         }
 
         EnsureEventProcessorStarted();
-        _eventChannel!.Writer.TryWrite(new(action, item, batch));
+        if (!_eventChannel!.Writer.TryWrite(new(action, item, batch)))
+        {
+            batch?.Dispose();
+        }
     }
 
     /// <summary>
@@ -280,9 +291,7 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
             return;
         }
 
-        var pool = ArrayPool<TItem>.Shared.Rent(count);
-        Array.Copy(items, pool, count);
-        Emit(CacheAction.BatchOperation, default, new PooledBatch<TItem>(pool, count));
+        Emit(CacheAction.BatchOperation, default, CreateBatch(items, count));
     }
 
     /// <summary>
@@ -303,9 +312,7 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
             return;
         }
 
-        var pool = ArrayPool<TItem>.Shared.Rent(count);
-        Array.Copy(items, pool, count);
-        Emit(CacheAction.BatchAdded, default, new PooledBatch<TItem>(pool, count));
+        Emit(CacheAction.BatchAdded, default, CreateBatch(items, count));
     }
 
     /// <summary>
@@ -331,13 +338,13 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
             return;
         }
 
-        var pool = ArrayPool<TItem>.Shared.Rent(count);
+        var pool = new TItem[count];
         for (var i = 0; i < count; i++)
         {
             pool[i] = items[i];
         }
 
-        Emit(CacheAction.BatchAdded, default, new PooledBatch<TItem>(pool, count));
+        Emit(CacheAction.BatchAdded, default, new PooledBatch<TItem>(pool, count, ReturnToPool: false));
     }
 
     /// <summary>
@@ -358,9 +365,7 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
             return;
         }
 
-        var pool = ArrayPool<TItem>.Shared.Rent(count);
-        Array.Copy(items, pool, count);
-        Emit(CacheAction.BatchRemoved, default, new PooledBatch<TItem>(pool, count));
+        Emit(CacheAction.BatchRemoved, default, CreateBatch(items, count));
     }
 
     /// <summary>
@@ -384,13 +389,13 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
             return;
         }
 
-        var pool = ArrayPool<TItem>.Shared.Rent(count);
+        var pool = new TItem[count];
         for (var i = 0; i < count; i++)
         {
             pool[i] = items[i];
         }
 
-        Emit(CacheAction.BatchRemoved, default, new PooledBatch<TItem>(pool, count));
+        Emit(CacheAction.BatchRemoved, default, new PooledBatch<TItem>(pool, count, ReturnToPool: false));
     }
 
     /// <summary>
@@ -452,6 +457,13 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
 
             IsDisposed = true;
         }
+    }
+
+    private static PooledBatch<TItem> CreateBatch(TItem[] items, int count)
+    {
+        var batchItems = new TItem[count];
+        Array.Copy(items, batchItems, count);
+        return new PooledBatch<TItem>(batchItems, count, ReturnToPool: false);
     }
 
     /// <summary>
@@ -555,6 +567,9 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
 
     private bool HasChangeObservers() =>
         Interlocked.CompareExchange(ref _hasSubscribers, 0, 0) != 0 || _collectionChanged != null;
+
+    private void OnPropertyChanged(PropertyChangedEventArgs args) =>
+        PropertyChanged?.Invoke(this, args);
 
     private void EnsureEventProcessorStarted()
     {

--- a/src/ReactiveList/Collections/QuaternaryBase.cs
+++ b/src/ReactiveList/Collections/QuaternaryBase.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
@@ -78,6 +79,7 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     private Subject<CacheNotify<TItem>>? _pipeline;
     private CancellationTokenSource? _cts;
     private NotifyCollectionChangedEventHandler? _collectionChanged;
+    private int _count;
     private int _eventProcessorStarted;
     private int _hasSubscribers;
     private long _version;
@@ -123,24 +125,7 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     public int Count
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
-        {
-            var count = 0;
-            for (var i = 0; i < ShardCount; i++)
-            {
-                Locks[i].EnterReadLock();
-                try
-                {
-                    count += Quads[i].Count;
-                }
-                finally
-                {
-                    Locks[i].ExitReadLock();
-                }
-            }
-
-            return count;
-        }
+        get => Volatile.Read(ref _count);
     }
 
     /// <summary>
@@ -160,9 +145,17 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     {
         get
         {
-            Volatile.Write(ref _hasSubscribers, 1);
-            EnsureEventProcessorStarted();
-            return _pipeline!.AsObservable();
+            return Observable.Create<CacheNotify<TItem>>(observer =>
+            {
+                EnsureEventProcessorStarted();
+                Interlocked.Increment(ref _hasSubscribers);
+                var subscription = _pipeline!.Subscribe(observer);
+                return Disposable.Create(() =>
+                {
+                    subscription.Dispose();
+                    Interlocked.Decrement(ref _hasSubscribers);
+                });
+            });
         }
     }
 
@@ -195,6 +188,8 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
             {
                 Quads[i].Clear();
             }
+
+            SetCount(0);
         }
         finally
         {
@@ -369,6 +364,23 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
     }
 
     /// <summary>
+    /// Emits a batch removed notification using an already-owned array.
+    /// </summary>
+    /// <param name="items">The owned array containing removed items.</param>
+    /// <param name="count">The number of valid items in <paramref name="items"/>.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void EmitOwnedBatchRemoved(TItem[] items, int count)
+    {
+        if (!HasChangeObservers())
+        {
+            Emit(CacheAction.BatchRemoved, default);
+            return;
+        }
+
+        Emit(CacheAction.BatchRemoved, default, new PooledBatch<TItem>(items, count, ReturnToPool: false));
+    }
+
+    /// <summary>
     /// Emits a notification that a batch of items has been removed from the list.
     /// </summary>
     /// <param name="items">The list containing the items that were removed. The first <paramref name="count"/> elements are considered
@@ -458,6 +470,28 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
             IsDisposed = true;
         }
     }
+
+    /// <summary>
+    /// Atomically adds the specified delta to the cached item count.
+    /// </summary>
+    /// <param name="value">The count delta to apply.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void AddToCount(int value) => Interlocked.Add(ref _count, value);
+
+    /// <summary>
+    /// Sets the cached item count to the specified value.
+    /// </summary>
+    /// <param name="value">The new count value.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void SetCount(int value) => Volatile.Write(ref _count, value);
+
+    /// <summary>
+    /// Gets a value indicating whether the collection has observable or INCC subscribers.
+    /// </summary>
+    /// <returns><see langword="true"/> when change notifications need to be materialized; otherwise, <see langword="false"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected bool HasChangeObservers() =>
+        Interlocked.CompareExchange(ref _hasSubscribers, 0, 0) != 0 || _collectionChanged != null;
 
     private static PooledBatch<TItem> CreateBatch(TItem[] items, int count)
     {
@@ -564,9 +598,6 @@ public abstract class QuaternaryBase<TItem, TQuad, TValue> : IReactiveSource<TIt
             handler.Invoke(this, args);
         }
     }
-
-    private bool HasChangeObservers() =>
-        Interlocked.CompareExchange(ref _hasSubscribers, 0, 0) != 0 || _collectionChanged != null;
 
     private void OnPropertyChanged(PropertyChangedEventArgs args) =>
         PropertyChanged?.Invoke(this, args);

--- a/src/ReactiveList/Collections/QuaternaryDictionary.cs
+++ b/src/ReactiveList/Collections/QuaternaryDictionary.cs
@@ -120,22 +120,28 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     public bool TryAdd(TKey key, TValue value)
     {
         var idx = GetShard(key);
+        var added = false;
         Locks[idx].EnterWriteLock();
         try
         {
             if (Quads[idx].TryAdd(key, value))
             {
                 NotifyIndicesAdded(value);
-                Emit(CacheAction.Added, new(key, value));
-                return true;
+                AddToCount(1);
+                added = true;
             }
-
-            return false;
         }
         finally
         {
             Locks[idx].ExitWriteLock();
         }
+
+        if (added)
+        {
+            Emit(CacheAction.Added, new(key, value));
+        }
+
+        return added;
     }
 
     /// <summary>
@@ -147,6 +153,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     public void AddOrUpdate(TKey key, TValue value)
     {
         var idx = GetShard(key);
+        var action = CacheAction.Updated;
         Locks[idx].EnterWriteLock();
         try
         {
@@ -160,19 +167,21 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
                 NotifyIndicesRemoved(valueRef!);
                 valueRef = value;
                 NotifyIndicesAdded(value);
-                Emit(CacheAction.Updated, new(key, value));
             }
             else
             {
                 valueRef = value;
                 NotifyIndicesAdded(value);
-                Emit(CacheAction.Added, new(key, value));
+                AddToCount(1);
+                action = CacheAction.Added;
             }
         }
         finally
         {
             Locks[idx].ExitWriteLock();
         }
+
+        Emit(action, new(key, value));
     }
 
     /// <summary>
@@ -184,22 +193,30 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     public bool Remove(TKey key)
     {
         var idx = GetShard(key);
+        TValue? removedValue = default;
+        var removed = false;
         Locks[idx].EnterWriteLock();
         try
         {
             if (Quads[idx].Remove(key, out var val))
             {
                 NotifyIndicesRemoved(val);
-                Emit(CacheAction.Removed, new(key, val));
-                return true;
+                AddToCount(-1);
+                removedValue = val;
+                removed = true;
             }
-
-            return false;
         }
         finally
         {
             Locks[idx].ExitWriteLock();
         }
+
+        if (removed)
+        {
+            Emit(CacheAction.Removed, new(key, removedValue!));
+        }
+
+        return removed;
     }
 
     /// <summary>
@@ -476,6 +493,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
 
             if (totalRemoved > 0)
             {
+                AddToCount(-totalRemoved);
                 Emit(CacheAction.BatchOperation, default);
             }
         }
@@ -505,6 +523,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
         {
             var wrapper = new QuaternaryDictEditWrapper(this);
             editAction(wrapper);
+            SetCount(GetCountUnsafe());
         }
         finally
         {
@@ -643,6 +662,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
                 }
 
                 var hasIndices = !Indices.IsEmpty;
+                var added = 0;
                 for (var i = 0; i < count; i++)
                 {
                     var kvp = itemsSpan[i];
@@ -654,11 +674,18 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
                     }
 
                     valueRef = kvp.Value;
+                    if (!exists)
+                    {
+                        added++;
+                    }
+
                     if (hasIndices)
                     {
                         NotifyIndicesAdded(kvp.Value);
                     }
                 }
+
+                AddToCount(added);
             }
             finally
             {
@@ -728,6 +755,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
                 }
 
                 var hasIndices = !Indices.IsEmpty;
+                var added = 0;
                 for (var i = 0; i < count; i++)
                 {
                     var kvp = items[i];
@@ -739,11 +767,18 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
                     }
 
                     valueRef = kvp.Value;
+                    if (!exists)
+                    {
+                        added++;
+                    }
+
                     if (hasIndices)
                     {
                         NotifyIndicesAdded(kvp.Value);
                     }
                 }
+
+                AddToCount(added);
             }
             finally
             {
@@ -780,106 +815,43 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
             return;
         }
 
-        var bucketCountsArray = new int[ShardCount];
-        var bucketIndicesArray = new int[ShardCount];
         var keysSpan = keys.AsSpan();
-
-        for (var i = 0; i < count; i++)
-        {
-            var shardIdx = GetShard(keysSpan[i]);
-            bucketCountsArray[shardIdx]++;
-        }
-
-        var bucketArrays = new TKey[ShardCount][];
+        var removed = 0;
 
         for (var i = 0; i < ShardCount; i++)
         {
-            bucketArrays[i] = bucketCountsArray[i] > 0 ? ArrayPool<TKey>.Shared.Rent(bucketCountsArray[i]) : [];
+            Locks[i].EnterWriteLock();
         }
 
         try
         {
+            var hasIndices = !Indices.IsEmpty;
             for (var i = 0; i < count; i++)
             {
                 var key = keysSpan[i];
                 var shardIdx = GetShard(key);
-                bucketArrays[shardIdx][bucketIndicesArray[shardIdx]++] = key;
-            }
-
-            if (count >= ParallelThreshold)
-            {
-                Parallel.For(0, ShardCount, sIdx =>
+                if (Quads[shardIdx].Remove(key, out var val))
                 {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
+                    removed++;
+                    if (hasIndices)
                     {
-                        return;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var dict = Quads[sIdx];
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var key = bucket[i];
-                            if (dict.Remove(key, out var val) && hasIndices)
-                            {
-                                NotifyIndicesRemoved(val);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                });
-            }
-            else
-            {
-                for (var sIdx = 0; sIdx < ShardCount; sIdx++)
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        continue;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var dict = Quads[sIdx];
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var key = bucket[i];
-                            if (dict.Remove(key, out var val) && hasIndices)
-                            {
-                                NotifyIndicesRemoved(val);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
+                        NotifyIndicesRemoved(val);
                     }
                 }
             }
-
-            Emit(CacheAction.BatchOperation, default);
         }
         finally
         {
-            for (var i = 0; i < ShardCount; i++)
+            for (var i = ShardCount - 1; i >= 0; i--)
             {
-                if (bucketCountsArray[i] > 0)
-                {
-                    ArrayPool<TKey>.Shared.Return(bucketArrays[i], clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
-                }
+                Locks[i].ExitWriteLock();
             }
+        }
+
+        if (removed > 0)
+        {
+            AddToCount(-removed);
+            Emit(CacheAction.BatchOperation, default);
         }
     }
 
@@ -899,106 +871,54 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
             return;
         }
 
-        var bucketCountsArray = new int[ShardCount];
-        var bucketIndicesArray = new int[ShardCount];
-
-        for (var i = 0; i < count; i++)
-        {
-            var shardIdx = GetShard(keys[i]);
-            bucketCountsArray[shardIdx]++;
-        }
-
-        var bucketArrays = new TKey[ShardCount][];
+        var removed = 0;
 
         for (var i = 0; i < ShardCount; i++)
         {
-            bucketArrays[i] = bucketCountsArray[i] > 0 ? ArrayPool<TKey>.Shared.Rent(bucketCountsArray[i]) : [];
+            Locks[i].EnterWriteLock();
         }
 
         try
         {
+            var hasIndices = !Indices.IsEmpty;
             for (var i = 0; i < count; i++)
             {
                 var key = keys[i];
                 var shardIdx = GetShard(key);
-                bucketArrays[shardIdx][bucketIndicesArray[shardIdx]++] = key;
-            }
-
-            if (count >= ParallelThreshold)
-            {
-                Parallel.For(0, ShardCount, sIdx =>
+                if (Quads[shardIdx].Remove(key, out var val))
                 {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
+                    removed++;
+                    if (hasIndices)
                     {
-                        return;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var dict = Quads[sIdx];
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var key = bucket[i];
-                            if (dict.Remove(key, out var val) && hasIndices)
-                            {
-                                NotifyIndicesRemoved(val);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                });
-            }
-            else
-            {
-                for (var sIdx = 0; sIdx < ShardCount; sIdx++)
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        continue;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var dict = Quads[sIdx];
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var key = bucket[i];
-                            if (dict.Remove(key, out var val) && hasIndices)
-                            {
-                                NotifyIndicesRemoved(val);
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
+                        NotifyIndicesRemoved(val);
                     }
                 }
             }
-
-            Emit(CacheAction.BatchOperation, default);
         }
         finally
         {
-            for (var i = 0; i < ShardCount; i++)
+            for (var i = ShardCount - 1; i >= 0; i--)
             {
-                if (bucketCountsArray[i] > 0)
-                {
-                    ArrayPool<TKey>.Shared.Return(bucketArrays[i], clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
-                }
+                Locks[i].ExitWriteLock();
             }
         }
+
+        if (removed > 0)
+        {
+            AddToCount(-removed);
+            Emit(CacheAction.BatchOperation, default);
+        }
+    }
+
+    private int GetCountUnsafe()
+    {
+        var count = 0;
+        for (var i = 0; i < ShardCount; i++)
+        {
+            count += Quads[i].Count;
+        }
+
+        return count;
     }
 
     /// <summary>

--- a/src/ReactiveList/Collections/QuaternaryList.cs
+++ b/src/ReactiveList/Collections/QuaternaryList.cs
@@ -64,6 +64,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
         try
         {
             Quads[idx].Add(item);
+            AddToCount(1);
             NotifyIndicesAdded(item);
         }
         finally
@@ -90,6 +91,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
             removed = Quads[idx].Remove(item);
             if (removed)
             {
+                AddToCount(-1);
                 NotifyIndicesRemoved(item);
             }
         }
@@ -183,6 +185,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                         if (predicate(item))
                         {
                             quad.RemoveAt(j);
+                            AddToCount(-1);
                             NotifyIndicesRemoved(item);
 
                             // Grow buffer if needed
@@ -236,6 +239,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
         {
             var wrapper = new QuaternaryEditWrapper(this);
             editAction(wrapper);
+            SetCount(GetCountUnsafe());
         }
         finally
         {
@@ -274,6 +278,8 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
             {
                 Quads[i].Clear();
             }
+
+            SetCount(0);
 
             foreach (var idx in Indices.Values)
             {
@@ -318,6 +324,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
 
                         var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
                         Quads[sIdx].AddRange(bucket);
+                        AddToCount(bucketCount);
 
                         if (!Indices.IsEmpty)
                         {
@@ -627,6 +634,8 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                         NotifyIndicesAdded(item);
                     }
                 }
+
+                AddToCount(count);
             }
             finally
             {
@@ -706,6 +715,8 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                         NotifyIndicesAdded(item);
                     }
                 }
+
+                AddToCount(count);
             }
             finally
             {
@@ -742,116 +753,19 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
             return;
         }
 
-        var bucketCountsArray = new int[ShardCount];
-        var bucketIndicesArray = new int[ShardCount];
-        var removedByShard = new List<T>?[ShardCount];
+        Dictionary<T, int>? remove0 = null;
+        Dictionary<T, int>? remove1 = null;
+        Dictionary<T, int>? remove2 = null;
+        Dictionary<T, int>? remove3 = null;
         var itemsSpan = items.AsSpan();
 
         for (var i = 0; i < count; i++)
         {
-            var shardIdx = GetShardIndex(itemsSpan[i]);
-            bucketCountsArray[shardIdx]++;
+            var item = itemsSpan[i];
+            AddRemoveCount(GetShardIndex(item), item, ref remove0, ref remove1, ref remove2, ref remove3);
         }
 
-        var bucketArrays = new T[ShardCount][];
-
-        for (var i = 0; i < ShardCount; i++)
-        {
-            bucketArrays[i] = bucketCountsArray[i] > 0 ? ArrayPool<T>.Shared.Rent(bucketCountsArray[i]) : Array.Empty<T>();
-        }
-
-        try
-        {
-            for (var i = 0; i < count; i++)
-            {
-                var item = itemsSpan[i];
-                var shardIdx = GetShardIndex(item);
-                bucketArrays[shardIdx][bucketIndicesArray[shardIdx]++] = item;
-            }
-
-            if (count >= ParallelThreshold)
-            {
-                Parallel.For(0, ShardCount, sIdx =>
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        return;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var quad = Quads[sIdx];
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var item = bucket[i];
-                            if (quad.Remove(item))
-                            {
-                                (removedByShard[sIdx] ??= []).Add(item);
-                                if (hasIndices)
-                                {
-                                    NotifyIndicesRemoved(item);
-                                }
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                });
-            }
-            else
-            {
-                for (var sIdx = 0; sIdx < ShardCount; sIdx++)
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        continue;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var quad = Quads[sIdx];
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var item = bucket[i];
-                            if (quad.Remove(item))
-                            {
-                                (removedByShard[sIdx] ??= []).Add(item);
-                                if (hasIndices)
-                                {
-                                    NotifyIndicesRemoved(item);
-                                }
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                }
-            }
-
-            EmitRemovedItems(removedByShard);
-        }
-        finally
-        {
-            for (var i = 0; i < ShardCount; i++)
-            {
-                if (bucketCountsArray[i] > 0)
-                {
-                    ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
-                }
-            }
-        }
+        RemoveFromShards(remove0, remove1, remove2, remove3);
     }
 
     /// <summary>
@@ -869,145 +783,148 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
             return;
         }
 
-        var bucketCountsArray = new int[ShardCount];
-        var bucketIndicesArray = new int[ShardCount];
-        var removedByShard = new List<T>?[ShardCount];
+        Dictionary<T, int>? remove0 = null;
+        Dictionary<T, int>? remove1 = null;
+        Dictionary<T, int>? remove2 = null;
+        Dictionary<T, int>? remove3 = null;
 
         for (var i = 0; i < count; i++)
         {
-            var shardIdx = GetShardIndex(items[i]);
-            bucketCountsArray[shardIdx]++;
+            var item = items[i];
+            AddRemoveCount(GetShardIndex(item), item, ref remove0, ref remove1, ref remove2, ref remove3);
         }
 
-        var bucketArrays = new T[ShardCount][];
-
-        for (var i = 0; i < ShardCount; i++)
-        {
-            bucketArrays[i] = bucketCountsArray[i] > 0 ? ArrayPool<T>.Shared.Rent(bucketCountsArray[i]) : Array.Empty<T>();
-        }
-
-        try
-        {
-            for (var i = 0; i < count; i++)
-            {
-                var item = items[i];
-                var shardIdx = GetShardIndex(item);
-                bucketArrays[shardIdx][bucketIndicesArray[shardIdx]++] = item;
-            }
-
-            if (count >= ParallelThreshold)
-            {
-                Parallel.For(0, ShardCount, sIdx =>
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        return;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var quad = Quads[sIdx];
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var item = bucket[i];
-                            if (quad.Remove(item))
-                            {
-                                (removedByShard[sIdx] ??= []).Add(item);
-                                if (hasIndices)
-                                {
-                                    NotifyIndicesRemoved(item);
-                                }
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                });
-            }
-            else
-            {
-                for (var sIdx = 0; sIdx < ShardCount; sIdx++)
-                {
-                    var bucketCount = bucketCountsArray[sIdx];
-                    if (bucketCount == 0)
-                    {
-                        continue;
-                    }
-
-                    var bucket = bucketArrays[sIdx].AsSpan(0, bucketCount);
-                    Locks[sIdx].EnterWriteLock();
-                    try
-                    {
-                        var quad = Quads[sIdx];
-                        var hasIndices = !Indices.IsEmpty;
-                        for (var i = 0; i < bucketCount; i++)
-                        {
-                            var item = bucket[i];
-                            if (quad.Remove(item))
-                            {
-                                (removedByShard[sIdx] ??= []).Add(item);
-                                if (hasIndices)
-                                {
-                                    NotifyIndicesRemoved(item);
-                                }
-                            }
-                        }
-                    }
-                    finally
-                    {
-                        Locks[sIdx].ExitWriteLock();
-                    }
-                }
-            }
-
-            EmitRemovedItems(removedByShard);
-        }
-        finally
-        {
-            for (var i = 0; i < ShardCount; i++)
-            {
-                if (bucketCountsArray[i] > 0)
-                {
-                    ArrayPool<T>.Shared.Return(bucketArrays[i], clearArray: CP.Reactive.Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
-                }
-            }
-        }
+        RemoveFromShards(remove0, remove1, remove2, remove3);
     }
 
-    private void EmitRemovedItems(List<T>?[] removedByShard)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Kept near related instance helpers to satisfy member ordering.")]
+    private void AddRemoveCount(
+        int shardIndex,
+        T item,
+        ref Dictionary<T, int>? remove0,
+        ref Dictionary<T, int>? remove1,
+        ref Dictionary<T, int>? remove2,
+        ref Dictionary<T, int>? remove3)
     {
-        var totalRemoved = 0;
-        for (var i = 0; i < removedByShard.Length; i++)
+        Dictionary<T, int>? counts;
+        switch (shardIndex)
         {
-            totalRemoved += removedByShard[i]?.Count ?? 0;
+            case 0:
+                counts = remove0 ??= [];
+                break;
+            case 1:
+                counts = remove1 ??= [];
+                break;
+            case 2:
+                counts = remove2 ??= [];
+                break;
+            default:
+                counts = remove3 ??= [];
+                break;
         }
+
+        counts[item] = counts.TryGetValue(item, out var existing) ? existing + 1 : 1;
+    }
+
+    private void RemoveFromShards(
+        Dictionary<T, int>? remove0,
+        Dictionary<T, int>? remove1,
+        Dictionary<T, int>? remove2,
+        Dictionary<T, int>? remove3)
+    {
+        var hasIndices = !Indices.IsEmpty;
+        var captureRemovedItems = hasIndices || HasChangeObservers();
+        var totalRemoved = 0;
+
+        var removed0 = RemoveFromShard(0, remove0, captureRemovedItems, hasIndices, ref totalRemoved);
+        var removed1 = RemoveFromShard(1, remove1, captureRemovedItems, hasIndices, ref totalRemoved);
+        var removed2 = RemoveFromShard(2, remove2, captureRemovedItems, hasIndices, ref totalRemoved);
+        var removed3 = RemoveFromShard(3, remove3, captureRemovedItems, hasIndices, ref totalRemoved);
 
         if (totalRemoved == 0)
         {
             return;
         }
 
-        var removed = new T[totalRemoved];
-        var offset = 0;
-        for (var i = 0; i < removedByShard.Length; i++)
-        {
-            var shardItems = removedByShard[i];
-            if (shardItems == null)
-            {
-                continue;
-            }
+        AddToCount(-totalRemoved);
+        EmitRemovedItems(totalRemoved, removed0, removed1, removed2, removed3);
+    }
 
-            shardItems.CopyTo(removed, offset);
-            offset += shardItems.Count;
+    private List<T>? RemoveFromShard(
+        int shardIndex,
+        Dictionary<T, int>? removeCounts,
+        bool captureRemovedItems,
+        bool hasIndices,
+        ref int totalRemoved)
+    {
+        if (removeCounts == null)
+        {
+            return null;
         }
 
-        EmitBatchRemoved(removed, removed.Length);
+        var removedItems = captureRemovedItems ? new List<T>(Math.Min(removeCounts.Count, Quads[shardIndex].Count)) : null;
+        Locks[shardIndex].EnterWriteLock();
+        try
+        {
+            totalRemoved += Quads[shardIndex].RemoveMatching(removeCounts, removedItems);
+        }
+        finally
+        {
+            Locks[shardIndex].ExitWriteLock();
+        }
+
+        if (hasIndices && removedItems != null)
+        {
+            for (var i = 0; i < removedItems.Count; i++)
+            {
+                NotifyIndicesRemoved(removedItems[i]);
+            }
+        }
+
+        return removedItems;
+    }
+
+    private void EmitRemovedItems(int totalRemoved, List<T>? removed0, List<T>? removed1, List<T>? removed2, List<T>? removed3)
+    {
+        if (!HasChangeObservers())
+        {
+            Emit(CacheAction.BatchRemoved, default);
+            return;
+        }
+
+        var removed = new T[totalRemoved];
+        var offset = 0;
+        CopyRemoved(removed0, removed, ref offset);
+        CopyRemoved(removed1, removed, ref offset);
+        CopyRemoved(removed2, removed, ref offset);
+        CopyRemoved(removed3, removed, ref offset);
+
+        EmitOwnedBatchRemoved(removed, removed.Length);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "Kept near related instance helpers to satisfy member ordering.")]
+    private void CopyRemoved(List<T>? source, T[] destination, ref int offset)
+    {
+        if (source == null)
+        {
+            return;
+        }
+
+        source.CopyTo(destination, offset);
+        offset += source.Count;
+    }
+
+    private int GetCountUnsafe()
+    {
+        var count = 0;
+        for (var i = 0; i < ShardCount; i++)
+        {
+            count += Quads[i].Count;
+        }
+
+        return count;
     }
 
     /// <summary>

--- a/src/ReactiveList/Collections/QuaternaryList.cs
+++ b/src/ReactiveList/Collections/QuaternaryList.cs
@@ -744,6 +744,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
 
         var bucketCountsArray = new int[ShardCount];
         var bucketIndicesArray = new int[ShardCount];
+        var removedByShard = new List<T>?[ShardCount];
         var itemsSpan = items.AsSpan();
 
         for (var i = 0; i < count; i++)
@@ -787,9 +788,13 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                         for (var i = 0; i < bucketCount; i++)
                         {
                             var item = bucket[i];
-                            if (quad.Remove(item) && hasIndices)
+                            if (quad.Remove(item))
                             {
-                                NotifyIndicesRemoved(item);
+                                (removedByShard[sIdx] ??= []).Add(item);
+                                if (hasIndices)
+                                {
+                                    NotifyIndicesRemoved(item);
+                                }
                             }
                         }
                     }
@@ -818,9 +823,13 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                         for (var i = 0; i < bucketCount; i++)
                         {
                             var item = bucket[i];
-                            if (quad.Remove(item) && hasIndices)
+                            if (quad.Remove(item))
                             {
-                                NotifyIndicesRemoved(item);
+                                (removedByShard[sIdx] ??= []).Add(item);
+                                if (hasIndices)
+                                {
+                                    NotifyIndicesRemoved(item);
+                                }
                             }
                         }
                     }
@@ -831,7 +840,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                 }
             }
 
-            EmitBatchRemoved(items, count);
+            EmitRemovedItems(removedByShard);
         }
         finally
         {
@@ -862,6 +871,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
 
         var bucketCountsArray = new int[ShardCount];
         var bucketIndicesArray = new int[ShardCount];
+        var removedByShard = new List<T>?[ShardCount];
 
         for (var i = 0; i < count; i++)
         {
@@ -904,9 +914,13 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                         for (var i = 0; i < bucketCount; i++)
                         {
                             var item = bucket[i];
-                            if (quad.Remove(item) && hasIndices)
+                            if (quad.Remove(item))
                             {
-                                NotifyIndicesRemoved(item);
+                                (removedByShard[sIdx] ??= []).Add(item);
+                                if (hasIndices)
+                                {
+                                    NotifyIndicesRemoved(item);
+                                }
                             }
                         }
                     }
@@ -935,9 +949,13 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                         for (var i = 0; i < bucketCount; i++)
                         {
                             var item = bucket[i];
-                            if (quad.Remove(item) && hasIndices)
+                            if (quad.Remove(item))
                             {
-                                NotifyIndicesRemoved(item);
+                                (removedByShard[sIdx] ??= []).Add(item);
+                                if (hasIndices)
+                                {
+                                    NotifyIndicesRemoved(item);
+                                }
                             }
                         }
                     }
@@ -948,7 +966,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                 }
             }
 
-            EmitBatchRemovedFromList(items, count);
+            EmitRemovedItems(removedByShard);
         }
         finally
         {
@@ -960,6 +978,36 @@ public class QuaternaryList<T> : QuaternaryBase<T, QuadList<T>, T>, IQuaternaryL
                 }
             }
         }
+    }
+
+    private void EmitRemovedItems(List<T>?[] removedByShard)
+    {
+        var totalRemoved = 0;
+        for (var i = 0; i < removedByShard.Length; i++)
+        {
+            totalRemoved += removedByShard[i]?.Count ?? 0;
+        }
+
+        if (totalRemoved == 0)
+        {
+            return;
+        }
+
+        var removed = new T[totalRemoved];
+        var offset = 0;
+        for (var i = 0; i < removedByShard.Length; i++)
+        {
+            var shardItems = removedByShard[i];
+            if (shardItems == null)
+            {
+                continue;
+            }
+
+            shardItems.CopyTo(removed, offset);
+            offset += shardItems.Count;
+        }
+
+        EmitBatchRemoved(removed, removed.Length);
     }
 
     /// <summary>

--- a/src/ReactiveList/Collections/Reactive2DList.cs
+++ b/src/ReactiveList/Collections/Reactive2DList.cs
@@ -88,10 +88,7 @@ public class Reactive2DList<T> : ReactiveList<ReactiveList<T>>
             throw new ArgumentNullException(nameof(items));
         }
 
-        foreach (var item in items)
-        {
-            Add([.. item]);
-        }
+        base.AddRange(items.Select(static item => new ReactiveList<T>(item)).ToArray());
     }
 
     /// <summary>
@@ -106,10 +103,7 @@ public class Reactive2DList<T> : ReactiveList<ReactiveList<T>>
             throw new ArgumentNullException(nameof(items));
         }
 
-        foreach (var item in items)
-        {
-            Add(new ReactiveList<T>(item));
-        }
+        base.AddRange(items.Select(static item => new ReactiveList<T>(item)).ToArray());
     }
 
     /// <summary>

--- a/src/ReactiveList/Collections/ReactiveList.cs
+++ b/src/ReactiveList/Collections/ReactiveList.cs
@@ -38,6 +38,9 @@ public class ReactiveList<T> : IReactiveList<T>
     where T : notnull
 {
     private const string ItemArray = "Item[]";
+    private static readonly PropertyChangedEventArgs CountPropertyChangedEventArgs = new(nameof(Count));
+    private static readonly PropertyChangedEventArgs ItemArrayPropertyChangedEventArgs = new(ItemArray);
+    private static readonly NotifyCollectionChangedEventArgs ResetCollectionChangedEventArgs = new(NotifyCollectionChangedAction.Reset);
     private readonly List<T> _internalList = [];
 
 #if NET9_0_OR_GREATER
@@ -91,7 +94,7 @@ public class ReactiveList<T> : IReactiveList<T>
     private Subject<CacheNotify<T>>? _streamPipeline;
 
     [NonSerialized]
-    private bool _skipInternalSubscription;
+    private int _skipInternalNotifications;
 
     [NonSerialized]
     private long _version;
@@ -234,22 +237,14 @@ public class ReactiveList<T> : IReactiveList<T>
     object? IList.this[int index]
     {
         get => _internalList[index];
-        set
-        {
-            RemoveAt(index);
-            Insert(index, (T)value!);
-        }
+        set => SetItem(index, (T)value!);
     }
 
     /// <inheritdoc/>
     public T this[int index]
     {
         get => _internalList[index];
-        set
-        {
-            RemoveAt(index);
-            Insert(index, value);
-        }
+        set => SetItem(index, value);
     }
 
     /// <inheritdoc/>
@@ -289,22 +284,17 @@ public class ReactiveList<T> : IReactiveList<T>
             return;
         }
 
+        var itemArray = items.ToArray();
         lock (_lock)
         {
-            var requiredCapacity = _internalList.Count + items.Length;
+            var requiredCapacity = _internalList.Count + itemArray.Length;
             if (_internalList.Capacity < requiredCapacity)
             {
                 _internalList.Capacity = requiredCapacity;
             }
 
-            foreach (var item in items)
-            {
-                _internalList.Add(item);
-                _observableItems!.Add(item);
-            }
-
-            // Notify with array copy
-            var itemArray = items.ToArray();
+            _internalList.AddRange(itemArray);
+            _observableItems!.AddRange(itemArray);
             NotifyAddedRange(itemArray);
         }
     }
@@ -563,38 +553,23 @@ public class ReactiveList<T> : IReactiveList<T>
 
         lock (_lock)
         {
-            var snapshotSet = new HashSet<T>(_internalList);
-            var wrapper = new EditableListWrapper<T>(_internalList, _observableItems);
+            var snapshot = _internalList.ToArray();
+            var wrapper = new EditableListWrapper<T>(_internalList);
             editAction(wrapper);
 
-            var currentSet = new HashSet<T>(_internalList);
-            var added = new List<T>();
-            var removed = new List<T>();
+            _observableItems!.ReplaceAll(_internalList);
 
-            foreach (var item in _internalList)
+            var added = GetMultisetDifference(_internalList, snapshot);
+            var removed = GetMultisetDifference(snapshot, _internalList);
+
+            if (added.Length > 0)
             {
-                if (!snapshotSet.Contains(item))
-                {
-                    added.Add(item);
-                }
+                NotifyAddedRange(added, notifyINPC: false);
             }
 
-            foreach (var item in snapshotSet)
+            if (removed.Length > 0)
             {
-                if (!currentSet.Contains(item))
-                {
-                    removed.Add(item);
-                }
-            }
-
-            if (added.Count > 0)
-            {
-                NotifyAddedRange([.. added], notifyINPC: false);
-            }
-
-            if (removed.Count > 0)
-            {
-                NotifyRemovedRange([.. removed], notifyINPC: false);
+                NotifyRemovedRange(removed, notifyINPC: false);
             }
 
             OnPropertyChanged(nameof(Count));
@@ -752,13 +727,13 @@ public class ReactiveList<T> : IReactiveList<T>
                 if (index >= 0)
                 {
                     _internalList.RemoveAt(index);
-                    _observableItems!.RemoveAt(index);
                     removed.Add(item);
                 }
             }
 
             if (removed.Count > 0)
             {
+                _observableItems!.ReplaceAll(_internalList);
                 NotifyRemovedRange([.. removed]);
             }
         }
@@ -798,7 +773,6 @@ public class ReactiveList<T> : IReactiveList<T>
                     if (predicate(item))
                     {
                         _internalList.RemoveAt(i);
-                        _observableItems!.RemoveAt(i);
 
                         // Grow buffer if needed
                         if (removedCount >= removedBuffer.Length)
@@ -815,6 +789,8 @@ public class ReactiveList<T> : IReactiveList<T>
 
                 if (removedCount > 0)
                 {
+                    _observableItems!.ReplaceAll(_internalList);
+
                     // Reverse in-place to maintain original order
                     removedBuffer.AsSpan(0, removedCount).Reverse();
                     NotifyRemovedRange(removedBuffer.AsSpan(0, removedCount).ToArray());
@@ -836,13 +812,14 @@ public class ReactiveList<T> : IReactiveList<T>
                 if (predicate(item))
                 {
                     _internalList.RemoveAt(i);
-                    _observableItems!.RemoveAt(i);
                     removed.Add(item);
                 }
             }
 
             if (removed.Count > 0)
             {
+                _observableItems!.ReplaceAll(_internalList);
+
                 // Reverse to maintain original order in notification
                 removed.Reverse();
                 NotifyRemovedRange([.. removed]);
@@ -942,25 +919,32 @@ public class ReactiveList<T> : IReactiveList<T>
             UpdateTrackingCollection(_itemsChangedCollection!, oldItems);
             _currentItems!.OnNext(_internalList);
 
-            // Set flag to skip internal subscription processing for the following events
-            _skipInternalSubscription = true;
-
-            // Emit events to Stream for external subscribers
+            var emittedNotifications = 0;
             if (oldItems.Length > 0)
             {
-                var removedPool = ArrayPool<T>.Shared.Rent(oldItems.Length);
-                Array.Copy(oldItems, removedPool, oldItems.Length);
-                _streamPipeline?.OnNext(new CacheNotify<T>(CacheAction.BatchRemoved, default, new PooledBatch<T>(removedPool, oldItems.Length)));
+                emittedNotifications++;
             }
-
-            // Keep flag set for the second event
-            _skipInternalSubscription = true;
 
             if (itemArray.Length > 0)
             {
-                var addedPool = ArrayPool<T>.Shared.Rent(itemArray.Length);
-                Array.Copy(itemArray, addedPool, itemArray.Length);
-                _streamPipeline?.OnNext(new CacheNotify<T>(CacheAction.BatchAdded, default, new PooledBatch<T>(addedPool, itemArray.Length)));
+                emittedNotifications++;
+            }
+
+            _skipInternalNotifications += emittedNotifications;
+
+            if (oldItems.Length > 0)
+            {
+                _streamPipeline?.OnNext(new CacheNotify<T>(CacheAction.BatchRemoved, default, CreateBatch(oldItems)));
+            }
+
+            if (itemArray.Length > 0)
+            {
+                _streamPipeline?.OnNext(new CacheNotify<T>(CacheAction.BatchAdded, default, CreateBatch(itemArray)));
+            }
+
+            if (emittedNotifications > 0)
+            {
+                RaiseCollectionChanged(new CacheNotify<T>(CacheAction.BatchOperation, default));
             }
 
             OnPropertyChanged(nameof(Count));
@@ -1011,7 +995,15 @@ public class ReactiveList<T> : IReactiveList<T>
     /// Raises a PropertyChanged event (per <see cref="INotifyPropertyChanged" />).
     /// </summary>
     /// <param name="propertyName">Name of the property.</param>
-    protected virtual void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    protected virtual void OnPropertyChanged(string propertyName)
+    {
+        var args = propertyName == nameof(Count)
+            ? CountPropertyChangedEventArgs
+            : propertyName == ItemArray
+                ? ItemArrayPropertyChangedEventArgs
+                : new PropertyChangedEventArgs(propertyName);
+        PropertyChanged?.Invoke(this, args);
+    }
 
     /// <summary>
     /// Determines whether the specified object is compatible with the generic type parameter T.
@@ -1032,6 +1024,45 @@ public class ReactiveList<T> : IReactiveList<T>
     /// completes.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void UpdateTrackingCollection(RangeObservableCollection target, T[] items) => target.ReplaceAll(items);
+
+    private static PooledBatch<T> CreateBatch(T[] items)
+    {
+        var batchItems = new T[items.Length];
+        Array.Copy(items, batchItems, items.Length);
+        return new PooledBatch<T>(batchItems, items.Length, ReturnToPool: false);
+    }
+
+    private static T[] GetMultisetDifference(IReadOnlyList<T> source, IReadOnlyList<T> subtract)
+    {
+        if (source.Count == 0)
+        {
+            return Array.Empty<T>();
+        }
+
+        var counts = new Dictionary<T, int>(subtract.Count);
+        for (var i = 0; i < subtract.Count; i++)
+        {
+            var item = subtract[i];
+            counts.TryGetValue(item, out var count);
+            counts[item] = count + 1;
+        }
+
+        List<T>? difference = null;
+        for (var i = 0; i < source.Count; i++)
+        {
+            var item = source[i];
+            if (counts.TryGetValue(item, out var count) && count > 0)
+            {
+                counts[item] = count - 1;
+                continue;
+            }
+
+            difference ??= [];
+            difference.Add(item);
+        }
+
+        return difference == null || difference.Count == 0 ? Array.Empty<T>() : [.. difference];
+    }
 
     /// <summary>
     /// Extracts items from a cache notification.
@@ -1056,6 +1087,22 @@ public class ReactiveList<T> : IReactiveList<T>
         }
 
         return Array.Empty<T>();
+    }
+
+    private void SetItem(int index, T value)
+    {
+        lock (_lock)
+        {
+            if (index < 0 || index >= _internalList.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            var oldValue = _internalList[index];
+            _internalList[index] = value;
+            _observableItems![index] = value;
+            NotifyChangedSingle(value, ChangeReason.Update, index, index, previous: oldValue);
+        }
     }
 
     /// <summary>
@@ -1111,10 +1158,9 @@ public class ReactiveList<T> : IReactiveList<T>
             .Subscribe(notification =>
             {
                 // Skip if tracking collections were already updated directly (e.g., ReplaceAll)
-                if (_skipInternalSubscription)
+                if (_skipInternalNotifications > 0)
                 {
-                    _skipInternalSubscription = false;
-                    RaiseCollectionChanged(notification);
+                    _skipInternalNotifications--;
                     return;
                 }
 
@@ -1187,7 +1233,12 @@ public class ReactiveList<T> : IReactiveList<T>
                 notification.Item,
                 notification.CurrentIndex,
                 notification.PreviousIndex),
-            _ => new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset)
+            CacheAction.Updated => new NotifyCollectionChangedEventArgs(
+                NotifyCollectionChangedAction.Replace,
+                notification.Item,
+                notification.Previous,
+                notification.CurrentIndex),
+            _ => ResetCollectionChangedEventArgs
         };
 
         CollectionChanged.Invoke(this, args);
@@ -1227,9 +1278,7 @@ public class ReactiveList<T> : IReactiveList<T>
     {
         Interlocked.Increment(ref _version);
         var startIndex = index >= 0 ? index : _internalList.Count - items.Length;
-        var pool = ArrayPool<T>.Shared.Rent(items.Length);
-        Array.Copy(items, pool, items.Length);
-        EmitStream(CacheAction.BatchAdded, default, new PooledBatch<T>(pool, items.Length), startIndex);
+        EmitStream(CacheAction.BatchAdded, default, CreateBatch(items), startIndex);
 
         if (notifyINPC)
         {
@@ -1269,9 +1318,7 @@ public class ReactiveList<T> : IReactiveList<T>
     private void NotifyRemovedRange(T[] items, bool notifyINPC = true)
     {
         Interlocked.Increment(ref _version);
-        var pool = ArrayPool<T>.Shared.Rent(items.Length);
-        Array.Copy(items, pool, items.Length);
-        EmitStream(CacheAction.BatchRemoved, default, new PooledBatch<T>(pool, items.Length));
+        EmitStream(CacheAction.BatchRemoved, default, CreateBatch(items));
 
         if (notifyINPC)
         {
@@ -1294,9 +1341,7 @@ public class ReactiveList<T> : IReactiveList<T>
         Interlocked.Increment(ref _version);
         if (clearedItems.Length > 0)
         {
-            var pool = ArrayPool<T>.Shared.Rent(clearedItems.Length);
-            Array.Copy(clearedItems, pool, clearedItems.Length);
-            EmitStream(CacheAction.Cleared, default, new PooledBatch<T>(pool, clearedItems.Length));
+            EmitStream(CacheAction.Cleared, default, CreateBatch(clearedItems));
         }
         else
         {
@@ -1443,9 +1488,9 @@ public class ReactiveList<T> : IReactiveList<T>
 
         private void RaiseReset()
         {
-            OnPropertyChanged(new PropertyChangedEventArgs(nameof(Count)));
-            OnPropertyChanged(new PropertyChangedEventArgs(ItemArray));
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            OnPropertyChanged(CountPropertyChangedEventArgs);
+            OnPropertyChanged(ItemArrayPropertyChangedEventArgs);
+            OnCollectionChanged(ResetCollectionChangedEventArgs);
         }
 
         private void EnsureCapacity(int capacity)

--- a/src/ReactiveList/Core/PooledBatch.cs
+++ b/src/ReactiveList/Core/PooledBatch.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using CP.Reactive.Internal;
 
 namespace CP.Reactive.Core;
 
@@ -15,7 +16,8 @@ namespace CP.Reactive.Core;
 /// <param name="Items">The array of items provided by the array pool. Must not be null.</param>
 /// <param name="Count">The number of valid items in the batch. Must be between 0 and the length of the <paramref name="Items"/> array,
 /// inclusive.</param>
-public sealed record PooledBatch<T>(T[] Items, int Count) : IDisposable
+/// <param name="ReturnToPool">A value indicating whether <paramref name="Items"/> should be returned to <see cref="ArrayPool{T}"/> when disposed.</param>
+public sealed record PooledBatch<T>(T[] Items, int Count, bool ReturnToPool = true) : IDisposable
 {
     private int _isDisposed;
 
@@ -28,7 +30,10 @@ public sealed record PooledBatch<T>(T[] Items, int Count) : IDisposable
     {
         if (Interlocked.Exchange(ref _isDisposed, 1) == 0)
         {
-            ArrayPool<T>.Shared.Return(Items);
+            if (ReturnToPool)
+            {
+                ArrayPool<T>.Shared.Return(Items, clearArray: ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
+            }
         }
     }
 }

--- a/src/ReactiveList/Core/ReactiveGroup.cs
+++ b/src/ReactiveList/Core/ReactiveGroup.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 
 namespace CP.Reactive.Core;
 
@@ -12,7 +13,7 @@ namespace CP.Reactive.Core;
 /// </summary>
 /// <typeparam name="TKey">The type of the grouping key.</typeparam>
 /// <typeparam name="T">The type of elements in the group.</typeparam>
-public sealed class ReactiveGroup<TKey, T> : IGrouping<TKey, T>, INotifyCollectionChanged
+public sealed class ReactiveGroup<TKey, T> : IGrouping<TKey, T>, INotifyCollectionChanged, INotifyPropertyChanged
     where TKey : notnull
 {
     private readonly ObservableCollection<T> _items;
@@ -27,11 +28,19 @@ public sealed class ReactiveGroup<TKey, T> : IGrouping<TKey, T>, INotifyCollecti
         Key = key;
         _items = items;
         Items = new ReadOnlyObservableCollection<T>(_items);
-        _items.CollectionChanged += (s, e) => CollectionChanged?.Invoke(this, e);
+        _items.CollectionChanged += (s, e) =>
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+            CollectionChanged?.Invoke(this, e);
+        };
     }
 
     /// <inheritdoc/>
     public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+    /// <inheritdoc/>
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     /// <summary>
     /// Gets the group key.

--- a/src/ReactiveList/ReactiveListExtensions.cs
+++ b/src/ReactiveList/ReactiveListExtensions.cs
@@ -316,7 +316,8 @@ public static class ReactiveListExtensions
             {
                 CacheAction.Added when notification.Item != null && filter(notification.Item) => notification,
                 CacheAction.Removed when notification.Item != null => notification, // Always pass removed items
-                CacheAction.BatchOperation when notification.Batch != null => FilterBatchByPredicate(notification, filter),
+                CacheAction.BatchAdded or CacheAction.BatchRemoved or CacheAction.BatchOperation when notification.Batch != null =>
+                    FilterBatchByPredicate(notification, filter),
                 CacheAction.Cleared => notification,
                 _ => null
             }).Where(n => n != null).Select(n => n!))
@@ -796,7 +797,23 @@ public static class ReactiveListExtensions
             throw new ArgumentNullException(nameof(source));
         }
 
-        return source.Stream.ToChangeSets();
+        return Observable.Defer(() =>
+        {
+            var initialItems = source.ToArray();
+            var changeStream = source.Stream.ToChangeSets();
+            if (initialItems.Length == 0)
+            {
+                return changeStream;
+            }
+
+            var initialChanges = new Change<T>[initialItems.Length];
+            for (var i = 0; i < initialItems.Length; i++)
+            {
+                initialChanges[i] = Change<T>.CreateAdd(initialItems[i], i);
+            }
+
+            return Observable.Return(new ChangeSet<T>(initialChanges)).Concat(changeStream);
+        });
     }
 
     /// <summary>
@@ -912,28 +929,33 @@ public static class ReactiveListExtensions
             return null;
         }
 
-        var filteredItems = new List<T>();
+        var matchCount = 0;
         for (var i = 0; i < notification.Batch.Count; i++)
         {
             var item = notification.Batch.Items[i];
             if (filter(item))
             {
-                filteredItems.Add(item);
+                matchCount++;
             }
         }
 
-        if (filteredItems.Count == 0)
+        if (matchCount == 0)
         {
             return null;
         }
 
-        var pooledArray = System.Buffers.ArrayPool<T>.Shared.Rent(filteredItems.Count);
-        for (var i = 0; i < filteredItems.Count; i++)
+        var filteredItems = new T[matchCount];
+        var index = 0;
+        for (var i = 0; i < notification.Batch.Count; i++)
         {
-            pooledArray[i] = filteredItems[i];
+            var item = notification.Batch.Items[i];
+            if (filter(item))
+            {
+                filteredItems[index++] = item;
+            }
         }
 
-        return new CacheNotify<T>(CacheAction.BatchOperation, default, new PooledBatch<T>(pooledArray, filteredItems.Count));
+        return new CacheNotify<T>(CacheAction.BatchOperation, default, new PooledBatch<T>(filteredItems, filteredItems.Length, ReturnToPool: false));
     }
 
     /// <summary>
@@ -953,27 +975,31 @@ public static class ReactiveListExtensions
             return null;
         }
 
-        var filteredItems = new List<T>();
+        var matchCount = 0;
+        for (var i = 0; i < notification.Batch.Count; i++)
+        {
+            if (matchingItems.Contains(notification.Batch.Items[i]))
+            {
+                matchCount++;
+            }
+        }
+
+        if (matchCount == 0)
+        {
+            return null;
+        }
+
+        var filteredItems = new T[matchCount];
+        var index = 0;
         for (var i = 0; i < notification.Batch.Count; i++)
         {
             var item = notification.Batch.Items[i];
             if (matchingItems.Contains(item))
             {
-                filteredItems.Add(item);
+                filteredItems[index++] = item;
             }
         }
 
-        if (filteredItems.Count == 0)
-        {
-            return null;
-        }
-
-        var pooledArray = System.Buffers.ArrayPool<T>.Shared.Rent(filteredItems.Count);
-        for (var i = 0; i < filteredItems.Count; i++)
-        {
-            pooledArray[i] = filteredItems[i];
-        }
-
-        return new CacheNotify<T>(CacheAction.BatchOperation, default, new PooledBatch<T>(pooledArray, filteredItems.Count));
+        return new CacheNotify<T>(CacheAction.BatchOperation, default, new PooledBatch<T>(filteredItems, filteredItems.Length, ReturnToPool: false));
     }
 }

--- a/src/ReactiveList/Views/DynamicReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicReactiveView.cs
@@ -82,22 +82,18 @@ where T : notnull
         _scheduler = scheduler;
         Items = new ReadOnlyObservableCollection<T>(_target);
 
-        // Get initial filter - for BehaviorSubject/ReplaySubject this should return immediately
-        try
+        var hasInitialFilter = TryGetLatest(filterObservable, out var initialFilter);
+        if (hasInitialFilter)
         {
-            _currentFilter = filterObservable.FirstAsync().GetAwaiter().GetResult() ?? (static _ => true);
-        }
-        catch
-        {
-            _currentFilter = static _ => true;
+            _currentFilter = initialFilter ?? (static _ => true);
         }
 
         RebuildView();
         SubscribeToStream();
 
         // Subscribe to subsequent filter changes with scheduler observation
-        filterObservable
-            .Skip(1)
+        var filterChanges = hasInitialFilter ? filterObservable.Skip(1) : filterObservable;
+        filterChanges
             .ObserveOn(scheduler)
             .Subscribe(newFilter =>
             {
@@ -188,50 +184,25 @@ where T : notnull
         }
     }
 
-    /// <summary>
-    /// Refreshes the view by reapplying the current filter to the source collection and updating the target collection
-    /// accordingly.
-    /// </summary>
-    /// <remarks>Call this method to ensure that the target collection reflects the latest state of the source
-    /// collection and filter. This method also raises the PropertyChanged event for the Items property to notify
-    /// listeners of the update.</remarks>
-    private void RebuildView()
+    private static bool TryGetLatest(IObservable<Func<T, bool>> source, out Func<T, bool>? value)
     {
-        _target.Clear();
-        foreach (var item in _source.Where(item => _currentFilter(item)))
+        var hasValue = false;
+        Func<T, bool>? current = null;
+        using (source.Subscribe(
+            next =>
+            {
+                if (!hasValue)
+                {
+                    current = next;
+                    hasValue = true;
+                }
+            },
+            _ => { }))
         {
-            _target.Add(item);
         }
 
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Items)));
-    }
-
-    /// <summary>
-    /// Subscribes to the data stream and updates the collection when new items are received.
-    /// </summary>
-    /// <remarks>Disposes any existing stream subscription before creating a new one. Updates to the
-    /// collection are batched and processed on the specified scheduler. Raises the PropertyChanged event for the Items
-    /// property after each batch is applied.</remarks>
-    private void SubscribeToStream()
-    {
-        // Dispose previous subscription
-        _streamSubscription?.Dispose();
-
-        // Subscribe to stream with current filter
-        _streamSubscription = _source.Stream
-            .Buffer(_throttle)
-            .Where(b => b.Count > 0)
-            .ObserveOn(_scheduler)
-            .Subscribe(batch =>
-            {
-                foreach (var notify in batch)
-                {
-                    ApplyChange(notify);
-                    notify.Batch?.Dispose();
-                }
-
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Items)));
-            });
+        value = current;
+        return hasValue;
     }
 
     /// <summary>
@@ -290,5 +261,51 @@ where T : notnull
                 _target.Clear();
                 break;
         }
+    }
+
+    /// <summary>
+    /// Refreshes the view by reapplying the current filter to the source collection and updating the target collection
+    /// accordingly.
+    /// </summary>
+    /// <remarks>Call this method to ensure that the target collection reflects the latest state of the source
+    /// collection and filter. This method also raises the PropertyChanged event for the Items property to notify
+    /// listeners of the update.</remarks>
+    private void RebuildView()
+    {
+        _target.Clear();
+        foreach (var item in _source.Where(item => _currentFilter(item)))
+        {
+            _target.Add(item);
+        }
+
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Items)));
+    }
+
+    /// <summary>
+    /// Subscribes to the data stream and updates the collection when new items are received.
+    /// </summary>
+    /// <remarks>Disposes any existing stream subscription before creating a new one. Updates to the
+    /// collection are batched and processed on the specified scheduler. Raises the PropertyChanged event for the Items
+    /// property after each batch is applied.</remarks>
+    private void SubscribeToStream()
+    {
+        // Dispose previous subscription
+        _streamSubscription?.Dispose();
+
+        // Subscribe to stream with current filter
+        _streamSubscription = _source.Stream
+            .Buffer(_throttle)
+            .Where(b => b.Count > 0)
+            .ObserveOn(_scheduler)
+            .Subscribe(batch =>
+            {
+                foreach (var notify in batch)
+                {
+                    ApplyChange(notify);
+                    notify.Batch?.Dispose();
+                }
+
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Items)));
+            });
     }
 }

--- a/src/ReactiveList/Views/DynamicSecondaryIndexDictionaryReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicSecondaryIndexDictionaryReactiveView.cs
@@ -57,14 +57,13 @@ where TIndexKey : notnull
         _filteredItems = [];
         Items = new ReadOnlyObservableCollection<KeyValuePair<TKey, TValue>>(_filteredItems);
 
-        // Get initial keys synchronously for BehaviorSubject/ReplaySubject
-        var initialKeys = keysObservable.FirstAsync().GetAwaiter().GetResult();
+        var hasInitialKeys = TryGetLatest(keysObservable, out var initialKeys);
         _currentKeys = initialKeys?.ToHashSet() ?? [];
         RebuildView();
 
         // Subscribe to key changes (skip the first since we already processed it)
-        keysObservable
-            .Skip(1)
+        var keyChanges = hasInitialKeys ? keysObservable.Skip(1) : keysObservable;
+        keyChanges
             .Subscribe(keys =>
             {
                 lock (_lock)
@@ -158,6 +157,27 @@ where TIndexKey : notnull
     public void Dispose()
     {
         _disposables.Dispose();
+    }
+
+    private static bool TryGetLatest(IObservable<TIndexKey[]> source, out TIndexKey[]? value)
+    {
+        var hasValue = false;
+        TIndexKey[]? current = null;
+        using (source.Subscribe(
+            next =>
+            {
+                if (!hasValue)
+                {
+                    current = next;
+                    hasValue = true;
+                }
+            },
+            _ => { }))
+        {
+        }
+
+        value = current;
+        return hasValue;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ReactiveList/Views/DynamicSecondaryIndexReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicSecondaryIndexReactiveView.cs
@@ -55,14 +55,13 @@ where TKey : notnull
         _filteredItems = [];
         Items = new ReadOnlyObservableCollection<T>(_filteredItems);
 
-        // Get initial keys synchronously for BehaviorSubject/ReplaySubject
-        var initialKeys = keysObservable.FirstAsync().GetAwaiter().GetResult();
+        var hasInitialKeys = TryGetLatest(keysObservable, out var initialKeys);
         _currentKeys = initialKeys?.ToHashSet() ?? [];
         RebuildView();
 
         // Subscribe to key changes (skip the first since we already processed it)
-        keysObservable
-            .Skip(1)
+        var keyChanges = hasInitialKeys ? keysObservable.Skip(1) : keysObservable;
+        keyChanges
             .Subscribe(keys =>
             {
                 lock (_lock)
@@ -156,6 +155,27 @@ where TKey : notnull
     public void Dispose()
     {
         _disposables.Dispose();
+    }
+
+    private static bool TryGetLatest(IObservable<TKey[]> source, out TKey[]? value)
+    {
+        var hasValue = false;
+        TKey[]? current = null;
+        using (source.Subscribe(
+            next =>
+            {
+                if (!hasValue)
+                {
+                    current = next;
+                    hasValue = true;
+                }
+            },
+            _ => { }))
+        {
+        }
+
+        value = current;
+        return hasValue;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Multiple changes to notification semantics, batching and view construction:

- Implement INotifyPropertyChanged across QuaternaryBase, ReactiveList and ReactiveGroup and cache common PropertyChanged/NotifyCollectionChanged EventArgs to reduce allocations and ensure Count/Item[] notifications on mutations.
- Refactor batching: introduce CreateBatch helpers, return PooledBatch with a ReturnToPool flag, and update usages to avoid returning pooled arrays containing live references. PooledBatch now conditionally returns arrays and uses ArrayPoolClearHelper when clearing.
- Optimize ReactiveList internals: use array copies / AddRange and ReplaceAll for observable backing collections, introduce GetMultisetDifference for Edit diffs, add SetItem helper, use an integer _skipInternalNotifications counter to coordinate internal vs external stream notifications, and raise batched collection/INPC events with fewer allocations.
- QuaternaryList: coalesce removed items by shard and emit a single batch via EmitRemovedItems, avoiding duplicate index notifications and preserving order.
- Views: make DynamicReactiveView, DynamicSecondaryIndexReactiveView and DynamicSecondaryIndexDictionaryReactiveView non-blocking at construction by using TryGetLatest to capture an initial filter/keys without blocking on FirstAsync, and adapt subscription handling accordingly.
- ReactiveListExtensions: make ToChangeSets emit an initial ChangeSet for preloaded sources; improve batch filtering to allocate exact-sized arrays and return non-pooled batches.
- Core: add CP.Reactive.Internal usage and minor namespace/using adjustments.
- Tests & benchmarks: add DynamicDataParityBenchmarks and ReactiveListNotificationComplianceTests; add a test asserting Connect emits an initial snapshot; adjust existing tests to ignore the initial Connect snapshot where appropriate.

These changes reduce allocation churn, avoid blocking on subjects at construction, and improve compliance with INPC/INCC contracts while simplifying batch lifecycle handling.