### PR TITLE
Modernize for .NET 11, global usings, and language features

### DIFF
--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -41,6 +41,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+            11.0.x
          dotnet-quality: 'preview'
          cache: true
          cache-dependency-path: |

--- a/.github/workflows/BuildDeploy.yml
+++ b/.github/workflows/BuildDeploy.yml
@@ -41,7 +41,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
-            11.0.x
+            11.0.100-preview.5.26302.115
          dotnet-quality: 'preview'
          cache: true
          cache-dependency-path: |

--- a/.github/workflows/BuildOnly.yml
+++ b/.github/workflows/BuildOnly.yml
@@ -37,7 +37,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
-            11.0.x
+            11.0.100-preview.5.26302.115
          dotnet-quality: 'preview'
          cache: true
          cache-dependency-path: |

--- a/.github/workflows/BuildOnly.yml
+++ b/.github/workflows/BuildOnly.yml
@@ -37,6 +37,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+            11.0.x
          dotnet-quality: 'preview'
          cache: true
          cache-dependency-path: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,8 +28,8 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
-    <CoreTargetFrameworks>net8.0;net9.0;net10.0</CoreTargetFrameworks>
-    <WinTargetFrameworks>net462;net472;net48;net481;net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</WinTargetFrameworks>
+    <CoreTargetFrameworks>net8.0;net9.0;net10.0;net11.0</CoreTargetFrameworks>
+    <WinTargetFrameworks>net462;net472;net48;net481;net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0;net11.0-windows10.0.19041.0</WinTargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
     <CoreTargetFrameworks>$(CoreTargetFrameworks);$(WinTargetFrameworks)</CoreTargetFrameworks>
@@ -45,6 +45,16 @@
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
     <PackageReference Include="TUnit" Version="1.56.0" />
   </ItemGroup>
+
+  <!-- Alias Lock to the dedicated System.Threading.Lock on .NET 9+ (faster EnterScope fast path),
+     and to a plain object elsewhere (the lock statement falls back to Monitor). -->
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+    <Using Include="System.Threading.Lock" Alias="Lock"/>
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+    <Using Include="System.Object" Alias="Lock"/>
+  </ItemGroup>
+  
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)images\logo.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="LICENSE" />
@@ -53,7 +63,7 @@
   
   <ItemGroup>
     <!--<Compile Update="**\*.cs" DependentUpon="I%(Filename).cs" />-->
-    <PackageReference Include="StyleSharp.Analyzers" Version="3.11.1" />
+    <PackageReference Include="StyleSharp.Analyzers" Version="3.11.2" PrivateAssets="All" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveList.Test/CoreCoverageTests.cs
+++ b/src/ReactiveList.Test/CoreCoverageTests.cs
@@ -120,7 +120,7 @@ public class CoreCoverageTests
         var batch = CreateBatch(42);
 
         subject.OnNext(new CacheNotify<int>(CacheAction.BatchAdded, default, batch));
-        Action disposeAgain = () => batch.Dispose();
+        Action disposeAgain = batch.Dispose;
 
         autoDisposed.Should().ContainSingle();
         disposeAgain.Should().NotThrow();
@@ -259,7 +259,7 @@ public class CoreCoverageTests
 
         using var set = new ChangeSet<int>(changes);
         using var single = new ChangeSet<int>(Change<int>.CreateRefresh(5, 4));
-        using var comparison = new ChangeSet<int>(changes.ToArray());
+        using var comparison = new ChangeSet<int>([.. changes]);
         var defaultSet = default(ChangeSet<int>);
 
         set.Count.Should().Be(4);
@@ -438,7 +438,7 @@ public class CoreCoverageTests
 
         var successValues = new List<int>();
         using var successSubscription = Observable
-            .Defer(() => ObservableFactoryValues.ToObservable())
+            .Defer(ObservableFactoryValues.ToObservable)
             .Subscribe(successValues.Add);
 
         successValues.Should().Equal(1, 2);
@@ -618,7 +618,7 @@ public class CoreCoverageTests
         using var noMatchBatch = CreateBatch(1, 2);
         var noMatchNotification = new CacheNotify<int>(CacheAction.BatchAdded, default, noMatchBatch);
         ReactiveListExtensions.FilterBatchByPredicate(noMatchNotification, static item => item > 10).Should().BeNull();
-        ReactiveListExtensions.FilterBatch(noMatchNotification, new HashSet<int> { 99 }).Should().BeNull();
+        ReactiveListExtensions.FilterBatch(noMatchNotification, [99]).Should().BeNull();
     }
 
     /// <summary>GroupBy should propagate upstream errors to active groups and to the outer subscriber.</summary>
@@ -631,7 +631,7 @@ public class CoreCoverageTests
         var upstreamError = new InvalidOperationException("group failure");
 
         using var subscription = ReactiveListExtensions
-            .GroupByChanges<int, int>(source, static value => value % 2)
+            .GroupByChanges(source, static value => value % 2)
             .Subscribe(
                 group =>
                 {
@@ -656,7 +656,7 @@ public class CoreCoverageTests
     {
         var source = new[] { ChangeSet<int>.Empty }.ToObservable();
         var results = ObservableMixins.ToEnumerable(
-                ReactiveListExtensions.SelectChanges<int, string>(
+                ReactiveListExtensions.SelectChanges(
                     source,
                     (Func<int, string>)(static value => value.ToString())))
             .ToList();

--- a/src/ReactiveList.Test/PooledBatchTests.cs
+++ b/src/ReactiveList.Test/PooledBatchTests.cs
@@ -60,7 +60,7 @@ public class PooledBatchTests
         var array = ArrayPool<int>.Shared.Rent(10);
         var batch = new PooledBatch<int>(array, 5);
 
-        var act = () => batch.Dispose();
+        var act = batch.Dispose;
 
         act.Should().NotThrow();
     }
@@ -73,7 +73,7 @@ public class PooledBatchTests
         var batch = new PooledBatch<int>(array, 5);
 
         batch.Dispose();
-        var act = () => batch.Dispose();
+        var act = batch.Dispose;
 
         act.Should().NotThrow();
     }

--- a/src/ReactiveList.Test/ReactiveListConnectTests.cs
+++ b/src/ReactiveList.Test/ReactiveListConnectTests.cs
@@ -37,7 +37,7 @@ public class ReactiveListConnectTests
         using var list = new ReactiveList<int>([1, 2, 3]);
         var receivedChanges = new List<ChangeSet<int>>();
 
-        using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        using var subscription = list.Connect().Subscribe(receivedChanges.Add);
 
         receivedChanges.Should().ContainSingle();
         receivedChanges[0].Count.Should().Be(3);
@@ -52,7 +52,7 @@ public class ReactiveListConnectTests
         // Arrange
         using var list = new ReactiveList<int>();
         var receivedChanges = new List<ChangeSet<int>>();
-        using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        using var subscription = list.Connect().Subscribe(receivedChanges.Add);
 
         // Act
         list.Add(42);
@@ -72,7 +72,7 @@ public class ReactiveListConnectTests
         // Arrange
         using var list = new ReactiveList<int>();
         var receivedChanges = new List<ChangeSet<int>>();
-        using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        using var subscription = list.Connect().Subscribe(receivedChanges.Add);
 
         // Act
         list.AddRange([1, 2, 3, 4, 5]);
@@ -90,7 +90,7 @@ public class ReactiveListConnectTests
         // Arrange
         using var list = new ReactiveList<int>([1, 2, 3]);
         var receivedChanges = new List<ChangeSet<int>>();
-        using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        using var subscription = list.Connect().Subscribe(receivedChanges.Add);
         receivedChanges.Clear();
 
         // Act
@@ -114,7 +114,7 @@ public class ReactiveListConnectTests
         // Arrange
         using var list = new ReactiveList<int>([1, 2, 3]);
         var receivedChanges = new List<ChangeSet<int>>();
-        using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        using var subscription = list.Connect().Subscribe(receivedChanges.Add);
         receivedChanges.Clear();
 
         // Act
@@ -136,7 +136,7 @@ public class ReactiveListConnectTests
         // Arrange
         using var list = new ReactiveList<int>([1, 2, 3, 4, 5]);
         var receivedChanges = new List<ChangeSet<int>>();
-        using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        using var subscription = list.Connect().Subscribe(receivedChanges.Add);
         receivedChanges.Clear();
 
         // Act
@@ -159,7 +159,7 @@ public class ReactiveListConnectTests
         // Arrange
         using var list = new ReactiveList<int>([1, 2, 3]);
         var receivedChanges = new List<ChangeSet<int>>();
-        using var subscription = list.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        using var subscription = list.Connect().Subscribe(receivedChanges.Add);
         receivedChanges.Clear();
 
         // Act

--- a/src/ReactiveList.Test/ReactiveListExtensionsAdditionalTests.cs
+++ b/src/ReactiveList.Test/ReactiveListExtensionsAdditionalTests.cs
@@ -31,7 +31,7 @@ public class ReactiveListExtensionsAdditionalTests
 
         using var subscription = list.Connect()
             .OnUpdate()
-            .Subscribe(update => updates.Add(update));
+            .Subscribe(updates.Add);
 
         // Act - use Update method (indexer does Remove+Add, not Update)
         list.Add("original");
@@ -102,7 +102,7 @@ public class ReactiveListExtensionsAdditionalTests
 
         using var subscription = list.Connect()
             .OnMove()
-            .Subscribe(move => moves.Add(move));
+            .Subscribe(moves.Add);
 
         // Act
         list.AddRange(new[] { "a", "b", "c", "d" });
@@ -146,7 +146,7 @@ public class ReactiveListExtensionsAdditionalTests
 
         using var subscription = list.Connect()
             .OnMove()
-            .Subscribe(move => moves.Add(move));
+            .Subscribe(moves.Add);
 
         // Act
         list.AddRange(new[] { 1, 2, 3, 4, 5 });
@@ -444,7 +444,7 @@ public class ReactiveListExtensionsAdditionalTests
 
         using var subscription = list.Connect()
             .GroupingByChanges(x => x % 2 == 0 ? "even" : "odd")
-            .Subscribe(grouping => groupings.Add(grouping));
+            .Subscribe(groupings.Add);
 
         // Act
         list.AddRange(new[] { 1, 2, 3, 4 });
@@ -463,7 +463,7 @@ public class ReactiveListExtensionsAdditionalTests
 
         using var subscription = list.Connect()
             .GroupingByChanges(x => x / 10) // Group by tens
-            .Subscribe(grouping => groupings.Add(grouping));
+            .Subscribe(groupings.Add);
 
         // Act - add items in different decades
         list.AddRange(new[] { 5, 15, 25, 7, 17 });
@@ -555,7 +555,7 @@ public class ReactiveListExtensionsAdditionalTests
         var changeSets = new List<ChangeSet<int>>();
 
         using var subscription = list.Connect()
-            .Subscribe(cs => changeSets.Add(cs));
+            .Subscribe(changeSets.Add);
 
         // Act
         list.Add(1);
@@ -758,7 +758,7 @@ public class ReactiveListExtensionsAdditionalTests
 
         using var subscription = list.Connect()
             .SelectChanges((int x) => $"Value:{x}")
-            .Subscribe(cs => transformedSets.Add(cs));
+            .Subscribe(transformedSets.Add);
 
         // Act
         list.Add(1);

--- a/src/ReactiveList.Test/ReactiveListExtensionsTests.cs
+++ b/src/ReactiveList.Test/ReactiveListExtensionsTests.cs
@@ -118,7 +118,7 @@ public class ReactiveListExtensionsTests
         // Use the overload that takes Func<Change<T>, TResult> to get individual transformed items
         using var subscription = list.Connect()
             .SelectChanges((Change<int> c) => $"Item_{c.Current}")
-            .Subscribe(item => transformedItems.Add(item));
+            .Subscribe(transformedItems.Add);
 
         // Act
         list.Add(1);

--- a/src/ReactiveList.Test/ReactiveListRemoveTests.cs
+++ b/src/ReactiveList.Test/ReactiveListRemoveTests.cs
@@ -405,7 +405,7 @@ public class ReactiveListRemoveTests
     {
         using var fixture = new ReactiveList<int>([1, 2, 3, 4, 5]);
         var receivedChanges = new System.Collections.Generic.List<ChangeSet<int>>();
-        using var subscription = fixture.Connect().Subscribe(cs => receivedChanges.Add(cs));
+        using var subscription = fixture.Connect().Subscribe(receivedChanges.Add);
         receivedChanges.Clear();
 
         var removed = fixture.RemoveMany(x => x > 3);

--- a/src/ReactiveList.Test/ReactiveViewTests.cs
+++ b/src/ReactiveList.Test/ReactiveViewTests.cs
@@ -309,7 +309,7 @@ public class ReactiveViewTests
             TimeSpan.FromMilliseconds(10),
             Sequencer.Immediate);
 
-        var act = () => view.Dispose();
+        var act = view.Dispose;
 
         act.Should().NotThrow();
     }
@@ -328,7 +328,7 @@ public class ReactiveViewTests
             Sequencer.Immediate);
 
         view.Dispose();
-        var act = () => view.Dispose();
+        var act = view.Dispose;
 
         act.Should().NotThrow();
     }

--- a/src/ReactiveList/Collections/IQuaternaryList.cs
+++ b/src/ReactiveList/Collections/IQuaternaryList.cs
@@ -2,8 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using CP.Reactive.Collections;
-
 namespace CP.Reactive.Collections;
 
 /// <summary>

--- a/src/ReactiveList/Collections/IReactiveList.cs
+++ b/src/ReactiveList/Collections/IReactiveList.cs
@@ -2,11 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using CP.Reactive.Core;
-
 namespace CP.Reactive.Collections;
 
 /// <summary>

--- a/src/ReactiveList/Collections/IReactiveSource.cs
+++ b/src/ReactiveList/Collections/IReactiveSource.cs
@@ -2,9 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Specialized;
-using CP.Reactive.Core;
-
 namespace CP.Reactive.Collections;
 
 /// <summary>Base interface for all reactive collections providing change observation.</summary>

--- a/src/ReactiveList/Collections/QuadDictionary.cs
+++ b/src/ReactiveList/Collections/QuadDictionary.cs
@@ -2,14 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-using System.Buffers;
-using System.Collections;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-
 namespace CP.Reactive.Collections;
 
 /// <summary>
@@ -763,4 +755,3 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
         internal void SetNext(int next) => _next = next;
     }
 }
-#endif

--- a/src/ReactiveList/Collections/QuadList.cs
+++ b/src/ReactiveList/Collections/QuadList.cs
@@ -2,11 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-using System.Buffers;
-using System.Collections;
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Collections;
 
 /// <summary>Provides a high-performance, pooled list for storing elements with fast add, remove, and enumeration operations.</summary>
@@ -411,4 +406,3 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
         }
     }
 }
-#endif

--- a/src/ReactiveList/Collections/QuaternaryBase.cs
+++ b/src/ReactiveList/Collections/QuaternaryBase.cs
@@ -2,19 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-
-using System.Collections.Concurrent;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using System.Threading.Channels;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Disposables;
-using ReactiveUI.Primitives.Signals;
-
 namespace CP.Reactive.Collections;
 
 /// <summary>
@@ -578,4 +565,3 @@ public abstract class QuaternaryBase<TItem, TValue> : IReactiveSource<TItem>, IN
         }
     }
 }
-#endif

--- a/src/ReactiveList/Collections/QuaternaryDictionary.cs
+++ b/src/ReactiveList/Collections/QuaternaryDictionary.cs
@@ -2,15 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-
-using System.Buffers;
-using System.Collections;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Core;
-using CP.Reactive.Views;
-
 namespace CP.Reactive.Collections;
 
 /// <summary>
@@ -1124,4 +1115,3 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }
-#endif

--- a/src/ReactiveList/Collections/QuaternaryList.cs
+++ b/src/ReactiveList/Collections/QuaternaryList.cs
@@ -2,16 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-
-using System.Buffers;
-using System.Collections;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-
 namespace CP.Reactive.Collections;
 
 /// <summary>
@@ -1109,4 +1099,3 @@ public class QuaternaryList<T> : QuaternaryBase<T, T>, IQuaternaryList<T>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }
-#endif

--- a/src/ReactiveList/Collections/Reactive2DList.cs
+++ b/src/ReactiveList/Collections/Reactive2DList.cs
@@ -2,10 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-
 namespace CP.Reactive.Collections;
 
 /// <summary>

--- a/src/ReactiveList/Collections/ReactiveList.cs
+++ b/src/ReactiveList/Collections/ReactiveList.cs
@@ -2,19 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Buffers;
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Signals;
-
 #if NET6_0_OR_GREATER
 using System.Runtime.InteropServices;
 #endif
@@ -47,13 +34,8 @@ public class ReactiveList<T> : IReactiveList<T>
 
     private readonly List<T> _internalList = [];
 
-#if NET9_0_OR_GREATER
     [NonSerialized]
     private Lock _lock = new();
-#else
-    [NonSerialized]
-    private object _lock = new();
-#endif
 
     [NonSerialized]
     private IObservable<IEnumerable<T>>? _added;
@@ -234,8 +216,6 @@ public class ReactiveList<T> : IReactiveList<T>
         }
     }
 
-#if NET6_0_OR_GREATER || NETFRAMEWORK
-
     /// <summary>Creates a snapshot of current items as an array.</summary>
     /// <returns>An array containing all current items.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -302,7 +282,7 @@ public class ReactiveList<T> : IReactiveList<T>
 #if NET6_0_OR_GREATER
         return CollectionsMarshal.AsSpan(_internalList);
 #else
-        return new ReadOnlySpan<T>(_internalList.ToArray());
+        return new ReadOnlySpan<T>([.. _internalList]);
 #endif
     }
 
@@ -349,7 +329,6 @@ public class ReactiveList<T> : IReactiveList<T>
             }
         }
     }
-#endif
 
     /// <inheritdoc/>
     public void Dispose()

--- a/src/ReactiveList/Core/CacheNotifyExtensions.cs
+++ b/src/ReactiveList/Core/CacheNotifyExtensions.cs
@@ -2,12 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-
 namespace CP.Reactive.Core;
 
 /// <summary>Provides extension methods for working with <see cref="CacheNotify{T}"/> streams across all reactive collection types.</summary>

--- a/src/ReactiveList/Core/ChangeSet.cs
+++ b/src/ReactiveList/Core/ChangeSet.cs
@@ -2,8 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-
 #if NET6_0_OR_GREATER
 using System.Buffers;
 using System.Runtime.CompilerServices;

--- a/src/ReactiveList/Core/EditableListWrapperPool.cs
+++ b/src/ReactiveList/Core/EditableListWrapperPool.cs
@@ -2,9 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Core;
 
 /// <summary>Provides a thread-safe object pool for reusing instances of <see cref="PooledEditableListWrapper{T}"/>.</summary>

--- a/src/ReactiveList/Core/GroupedObservable.cs
+++ b/src/ReactiveList/Core/GroupedObservable.cs
@@ -2,8 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using ReactiveUI.Primitives.Signals;
-
 namespace CP.Reactive.Core;
 
 /// <summary>Represents a grouped observable sequence keyed by <typeparamref name="TKey"/>.</summary>

--- a/src/ReactiveList/Core/PooledBatch.cs
+++ b/src/ReactiveList/Core/PooledBatch.cs
@@ -2,9 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Buffers;
-using CP.Reactive.Internal;
-
 namespace CP.Reactive.Core;
 
 /// <summary>Represents a batch of items obtained from an array pool, along with the number of valid items in the batch.</summary>

--- a/src/ReactiveList/Core/PooledEditableListWrapper.cs
+++ b/src/ReactiveList/Core/PooledEditableListWrapper.cs
@@ -2,10 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Internal;
-
 namespace CP.Reactive.Core;
 
 /// <summary>A pooled version of <see cref="EditableListWrapper{T}"/> that supports reuse through object pooling.</summary>

--- a/src/ReactiveList/Core/ReactiveGroup.cs
+++ b/src/ReactiveList/Core/ReactiveGroup.cs
@@ -2,11 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-
 namespace CP.Reactive.Core;
 
 /// <summary>Represents a group of items with a key for use in grouped views.</summary>

--- a/src/ReactiveList/Core/SecondaryIndex.cs
+++ b/src/ReactiveList/Core/SecondaryIndex.cs
@@ -2,9 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Core;
 
 /// <summary>Provides a thread-safe secondary index for associating items with keys derived from a selector function.</summary>

--- a/src/ReactiveList/Internal/ArrayPoolClearHelper.cs
+++ b/src/ReactiveList/Internal/ArrayPoolClearHelper.cs
@@ -2,8 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>Provides target-framework-compatible array-pool clearing decisions.</summary>

--- a/src/ReactiveList/Internal/BatchChangeTracker.cs
+++ b/src/ReactiveList/Internal/BatchChangeTracker.cs
@@ -2,11 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-
-using System.Buffers;
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>Provides batch change tracking for efficient event coalescing.</summary>
@@ -99,4 +94,3 @@ internal struct BatchChangeTracker<T> : IDisposable
         _removedItems = newArray;
     }
 }
-#endif

--- a/src/ReactiveList/Internal/BitOperationsCompat.cs
+++ b/src/ReactiveList/Internal/BitOperationsCompat.cs
@@ -2,8 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>Provides bit operations used by pooled collection sizing.</summary>

--- a/src/ReactiveList/Internal/ChangeGrouping.cs
+++ b/src/ReactiveList/Internal/ChangeGrouping.cs
@@ -2,8 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>A simple grouping implementation for change grouping.</summary>

--- a/src/ReactiveList/Internal/ChangeToken.cs
+++ b/src/ReactiveList/Internal/ChangeToken.cs
@@ -2,10 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>Represents a change token for tracking collection modifications with minimal allocations.</summary>
@@ -33,4 +29,3 @@ internal readonly record struct ChangeToken<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly bool HasChanged(long currentVersion) => Version != currentVersion;
 }
-#endif

--- a/src/ReactiveList/Internal/EditableListWrapper.cs
+++ b/src/ReactiveList/Internal/EditableListWrapper.cs
@@ -2,10 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.ObjectModel;
-using CP.Reactive.Core;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>

--- a/src/ReactiveList/Internal/Observable.cs
+++ b/src/ReactiveList/Internal/Observable.cs
@@ -2,10 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.ComponentModel;
-using ReactiveUI.Primitives.Disposables;
-using ReactiveUI.Primitives.Signals;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>Minimal observable factories used by ReactiveList internals.</summary>

--- a/src/ReactiveList/Internal/ObservableMixins.cs
+++ b/src/ReactiveList/Internal/ObservableMixins.cs
@@ -2,12 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Runtime.ExceptionServices;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-using ReactiveUI.Primitives.Signals;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>Internal observable helpers used to keep ReactiveList source compact while depending on ReactiveUI.Primitives.</summary>

--- a/src/ReactiveList/Internal/PooledBuffer.cs
+++ b/src/ReactiveList/Internal/PooledBuffer.cs
@@ -2,11 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-
-using System.Buffers;
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>Represents a rented array buffer with tracking of the used length.</summary>
@@ -56,4 +51,3 @@ internal sealed class PooledBuffer<T> : IDisposable
         _buffer = null!;
     }
 }
-#endif

--- a/src/ReactiveList/Internal/ShardHash.cs
+++ b/src/ReactiveList/Internal/ShardHash.cs
@@ -2,10 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>Provides optimized hash code calculation for sharding.</summary>
@@ -43,4 +39,3 @@ internal static class ShardHash
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int BitCount(int n) => BitOperationsCompat.Log2((uint)n);
 }
-#endif

--- a/src/ReactiveList/Internal/ThrowHelper.cs
+++ b/src/ReactiveList/Internal/ThrowHelper.cs
@@ -2,8 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>Provides target-framework-compatible guard helpers.</summary>

--- a/src/ReactiveList/Internal/ValueBuffer.cs
+++ b/src/ReactiveList/Internal/ValueBuffer.cs
@@ -2,11 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-
-using System.Buffers;
-using System.Runtime.CompilerServices;
-
 namespace CP.Reactive.Internal;
 
 /// <summary>
@@ -100,4 +95,3 @@ internal ref struct ValueBuffer<T>
         _rentedArray = newArray;
     }
 }
-#endif

--- a/src/ReactiveList/QuaternaryExtensions.cs
+++ b/src/ReactiveList/QuaternaryExtensions.cs
@@ -2,16 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using CP.Reactive.Views;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Signals;
-
 namespace CP.Reactive;
 
 /// <summary>
@@ -353,4 +343,3 @@ public static class QuaternaryExtensions
         }
     }
 }
-#endif

--- a/src/ReactiveList/ReactiveList.csproj
+++ b/src/ReactiveList/ReactiveList.csproj
@@ -8,7 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
     <!-- Required for SkipLocalsInit attribute to reduce zero-initialization overhead -->
   </PropertyGroup>
@@ -26,6 +26,32 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ReactiveList.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Buffers"/>
+    <Using Include="System.Collections"/>
+    <Using Include="System.Diagnostics"/>
+    <Using Include="System.Diagnostics.CodeAnalysis"/>
+    <Using Include="System.Runtime.CompilerServices"/>
+    <Using Include="System.Runtime.InteropServices"/>
+    <Using Include="System.Runtime.InteropServices"/>
+    <Using Include="System.Collections.Concurrent"/>
+    <Using Include="System.Collections.Specialized"/>
+    <Using Include="System.ComponentModel"/>
+    <Using Include="System.Threading.Channels"/>
+    <Using Include="CP.Reactive.Core"/>
+    <Using Include="CP.Reactive.Collections"/>
+    <Using Include="CP.Reactive.Internal"/>
+    <Using Include="CP.Reactive.Views"/>
+    <Using Include="System.Collections.ObjectModel"/>
+    <Using Include="System.Runtime.Serialization"/>
+    <Using Include="System.Runtime.ExceptionServices"/>
+    <Using Include="System.Linq.Expressions"/>
+    <Using Include="ReactiveUI.Primitives.Concurrency"/>
+    <Using Include="ReactiveUI.Primitives"/>
+    <Using Include="ReactiveUI.Primitives.Disposables"/>
+    <Using Include="ReactiveUI.Primitives.Signals"/>
   </ItemGroup>
 
 </Project>

--- a/src/ReactiveList/ReactiveListExtensions.cs
+++ b/src/ReactiveList/ReactiveListExtensions.cs
@@ -2,16 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using CP.Reactive.Views;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Signals;
-
 namespace CP.Reactive;
 
 /// <summary>Provides extension methods for reactive list operations including filtering, transforming, and observing changes.</summary>

--- a/src/ReactiveList/Views/DynamicFilteredReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicFilteredReactiveView.cs
@@ -2,18 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-
 namespace CP.Reactive.Views;
 
 /// <summary>
@@ -28,13 +16,9 @@ where T : notnull
 
     private readonly ObservableCollection<T> _filteredItems;
 
-    private readonly MultipleDisposable _disposables = new();
+    private readonly MultipleDisposable _disposables = [];
 
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
 
     private Func<T, bool> _currentFilter;
 

--- a/src/ReactiveList/Views/DynamicReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicReactiveView.cs
@@ -2,15 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-
 namespace CP.Reactive.Views;
 
 /// <summary>
@@ -32,7 +23,7 @@ where T : notnull
 
     private readonly IReactiveSource<T> _source;
 
-    private readonly MultipleDisposable _disposables = new();
+    private readonly MultipleDisposable _disposables = [];
 
     private readonly ISequencer _scheduler;
 

--- a/src/ReactiveList/Views/DynamicSecondaryIndexDictionaryReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicSecondaryIndexDictionaryReactiveView.cs
@@ -2,19 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-
 namespace CP.Reactive.Views;
 
 /// <summary>
@@ -338,4 +325,3 @@ where TKey : notnull
     private void OnPropertyChanged(string propertyName) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }
-#endif

--- a/src/ReactiveList/Views/DynamicSecondaryIndexReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicSecondaryIndexReactiveView.cs
@@ -2,19 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-
 namespace CP.Reactive.Views;
 
 /// <summary>
@@ -33,13 +20,9 @@ where TKey : notnull
 
     private readonly ObservableCollection<T> _filteredItems;
 
-    private readonly MultipleDisposable _disposables = new();
+    private readonly MultipleDisposable _disposables = [];
 
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
 
     private HashSet<TKey> _currentKeys = [];
 
@@ -253,7 +236,7 @@ where TKey : notnull
         // Explicitly specify TKey to ensure type inference is correct
         foreach (var key in _currentKeys)
         {
-            foreach (var item in _source.GetItemsBySecondaryIndex<TKey>(_indexName, key))
+            foreach (var item in _source.GetItemsBySecondaryIndex(_indexName, key))
             {
                 // Avoid duplicates if same item matches multiple keys
                 if (!_filteredItems.Contains(item))
@@ -268,11 +251,10 @@ where TKey : notnull
     /// <param name="item">The item value.</param>
     /// <returns><see langword="true"/> when the item matches any current key; otherwise, <see langword="false"/>.</returns>
     private bool ItemMatchesCurrentKeys(T item) =>
-        _currentKeys.Any(key => _source.ItemMatchesSecondaryIndex<TKey>(_indexName, item, key));
+        _currentKeys.Any(key => _source.ItemMatchesSecondaryIndex(_indexName, item, key));
 
     /// <summary>Handles property change notifications.</summary>
     /// <param name="propertyName">The propertyName value.</param>
     private void OnPropertyChanged(string propertyName) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }
-#endif

--- a/src/ReactiveList/Views/FilteredReactiveView.cs
+++ b/src/ReactiveList/Views/FilteredReactiveView.cs
@@ -2,18 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-
 namespace CP.Reactive.Views;
 
 /// <summary>Provides a filtered, read-only view over a <see cref="IReactiveList{T}"/> that automatically updates when the source list changes.</summary>
@@ -27,13 +15,9 @@ where T : notnull
 
     private readonly ObservableCollection<T> _filteredItems;
 
-    private readonly MultipleDisposable _disposables = new();
+    private readonly MultipleDisposable _disposables = [];
 
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
 
     /// <summary>Initializes a new instance of the <see cref="FilteredReactiveView{T}"/> class.</summary>
     /// <param name="source">The source reactive list to filter.</param>

--- a/src/ReactiveList/Views/GroupedReactiveView.cs
+++ b/src/ReactiveList/Views/GroupedReactiveView.cs
@@ -2,18 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-
 namespace CP.Reactive.Views;
 
 /// <summary>Provides a grouped view over a <see cref="IReactiveList{T}"/> that automatically updates when the source list changes.</summary>
@@ -31,13 +19,9 @@ where TKey : notnull
 
     private readonly ObservableCollection<ReactiveGroup<TKey, T>> _groupCollection = [];
 
-    private readonly MultipleDisposable _disposables = new();
+    private readonly MultipleDisposable _disposables = [];
 
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
 
     /// <summary>Initializes a new instance of the <see cref="GroupedReactiveView{T, TKey}"/> class.</summary>
     /// <param name="source">The source reactive list to group.</param>

--- a/src/ReactiveList/Views/IReactiveView.cs
+++ b/src/ReactiveList/Views/IReactiveView.cs
@@ -2,8 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
-
 namespace CP.Reactive.Views;
 
 /// <summary>Defines methods for binding a reactive view's items collection to a property.</summary>

--- a/src/ReactiveList/Views/ReactiveView.cs
+++ b/src/ReactiveList/Views/ReactiveView.cs
@@ -2,13 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-
 namespace CP.Reactive.Views;
 
 /// <summary>

--- a/src/ReactiveList/Views/SecondaryIndexReactiveView.cs
+++ b/src/ReactiveList/Views/SecondaryIndexReactiveView.cs
@@ -2,19 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if NET8_0_OR_GREATER || NETFRAMEWORK
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-
 namespace CP.Reactive.Views;
 
 /// <summary>
@@ -38,13 +25,9 @@ where TKey : notnull
 
     private readonly ObservableCollection<TValue> _filteredItems;
 
-    private readonly MultipleDisposable _disposables = new();
+    private readonly MultipleDisposable _disposables = [];
 
-#if NET9_0_OR_GREATER
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new();
-#endif
 
     /// <summary>Initializes a new instance of the <see cref="SecondaryIndexReactiveView{TKey, TValue}"/> class.</summary>
     /// <param name="source">The source dictionary to filter.</param>
@@ -126,7 +109,7 @@ where TKey : notnull
             indexKey!,
             scheduler,
             throttle,
-            static (dict, name, key) => dict.GetValuesBySecondaryIndex<TIndexKey>(name, (TIndexKey)key),
+            static (dict, name, key) => dict.GetValuesBySecondaryIndex(name, (TIndexKey)key),
             static (dict, name, value, key) => dict.ValueMatchesSecondaryIndex(name, value, (TIndexKey)key));
     }
 
@@ -244,4 +227,3 @@ where TKey : notnull
     private void OnPropertyChanged(string propertyName) =>
         PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 }
-#endif

--- a/src/ReactiveList/Views/SortedReactiveView.cs
+++ b/src/ReactiveList/Views/SortedReactiveView.cs
@@ -2,18 +2,6 @@
 // Chris Pulman and Contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
-using CP.Reactive.Collections;
-using CP.Reactive.Core;
-using CP.Reactive.Internal;
-using ReactiveUI.Primitives;
-using ReactiveUI.Primitives.Concurrency;
-using ReactiveUI.Primitives.Disposables;
-
 namespace CP.Reactive.Views;
 
 /// <summary>Provides a sorted, read-only view over a <see cref="IReactiveList{T}"/> that automatically updates when the source list changes.</summary>
@@ -27,12 +15,9 @@ where T : notnull
 
     private readonly ObservableCollection<T> _sortedItems;
 
-    private readonly MultipleDisposable _disposables = new();
-#if NET9_0_OR_GREATER
+    private readonly MultipleDisposable _disposables = [];
+
     private readonly Lock _lock = new();
-#else
-    private readonly object _lock = new object();
-#endif
 
     /// <summary>Initializes a new instance of the <see cref="SortedReactiveView{T}"/> class.</summary>
     /// <param name="source">The source reactive list to sort.</param>


### PR DESCRIPTION
Add net11 to target frameworks and enable a project-wide set of global Using imports in ReactiveList.csproj; simplify AOT condition. Move many per-file using directives into the project-level <Using> items and remove a lot of conditional compilation wrappers. Add an Alias "Lock" in Directory.Build.props (map to System.Threading.Lock on net9+ or object otherwise) and update StyleSharp analyzer to 3.11.2 (PrivateAssets=All). Apply code modernizations across tests and library code: replace small lambdas with method-group conversions, use target-typed new/collection expressions and range syntax where appropriate, simplify span/array handling, and collapse framework-specific #if blocks. These changes reduce boilerplate, remove redundant imports, and align the codebase with newer C#/.NET runtime features for cleaner, more maintainable code.