### PR TITLE
refactor: reduce ReactiveList analyzer noise

### DIFF
--- a/src/ReactiveList/Collections/QuadDictionary.cs
+++ b/src/ReactiveList/Collections/QuadDictionary.cs
@@ -126,15 +126,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
     public TValue this[TKey key]
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
-        {
-            if (TryGetValue(key, out var value))
-            {
-                return value;
-            }
-
-            throw new KeyNotFoundException();
-        }
+        get => TryGetValue(key, out var value) ? value : throw new KeyNotFoundException();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         set
@@ -285,12 +277,12 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
                 }
 
                 // Clear entry and add to free list
-                if (Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>())
+                if (ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>())
                 {
                     entry.SetKey(default!);
                 }
 
-                if (Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TValue>())
+                if (ArrayPoolClearHelper.IsReferenceOrContainsReferences<TValue>())
                 {
                     entry.SetValue(default);
                 }
@@ -319,7 +311,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
         }
 
         _buckets.AsSpan(0, _bucketsLength).Clear();
-        if (Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<Entry>())
+        if (ArrayPoolClearHelper.IsReferenceOrContainsReferences<Entry>())
         {
             _entries.AsSpan(0, _entryIndex).Clear();
         }
@@ -339,7 +331,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
         }
 
         var requiredBucketCount = (int)Math.Ceiling(capacity / LoadFactor);
-        var newSize = Internal.BitOperationsCompat.RoundUpToPowerOf2((uint)requiredBucketCount);
+        var newSize = BitOperationsCompat.RoundUpToPowerOf2((uint)requiredBucketCount);
         ResizeTo((int)newSize);
     }
 
@@ -357,10 +349,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
     /// <param name="list">The list to copy to.</param>
     public void CopyKeysTo(List<TKey> list)
     {
-        if (list is null)
-        {
-            throw new ArgumentNullException(nameof(list));
-        }
+        ThrowHelper.ThrowIfNull(list);
 
         for (var i = 0; i < _entryIndex; i++)
         {
@@ -378,10 +367,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
     /// <param name="list">The list to copy to.</param>
     public void CopyValuesTo(List<TValue> list)
     {
-        if (list is null)
-        {
-            throw new ArgumentNullException(nameof(list));
-        }
+        ThrowHelper.ThrowIfNull(list);
 
         for (var i = 0; i < _entryIndex; i++)
         {
@@ -399,10 +385,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
     /// <param name="list">The list to copy to.</param>
     public void CopyTo(List<KeyValuePair<TKey, TValue>> list)
     {
-        if (list is null)
-        {
-            throw new ArgumentNullException(nameof(list));
-        }
+        ThrowHelper.ThrowIfNull(list);
 
         for (var i = 0; i < _entryIndex; i++)
         {
@@ -430,7 +413,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
             return;
         }
 
-        ArrayPool<Entry>.Shared.Return(_entries, clearArray: Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<Entry>());
+        ArrayPool<Entry>.Shared.Return(_entries, clearArray: ArrayPoolClearHelper.IsReferenceOrContainsReferences<Entry>());
         _entries = null!;
     }
 
@@ -481,7 +464,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
     /// <remarks>The new capacity is rounded up to the next power of two to optimize memory usage and
     /// performance. This method is intended for internal use and should not be called directly by consumers of the
     /// class.</remarks>
-    private void Resize() => ResizeTo((int)Internal.BitOperationsCompat.RoundUpToPowerOf2((uint)_entries.Length * 2));
+    private void Resize() => ResizeTo((int)BitOperationsCompat.RoundUpToPowerOf2((uint)_entries.Length * 2));
 
     /// <summary>Resizes the internal storage arrays to accommodate the specified number of entries.</summary>
     /// <remarks>This method reinitializes the internal buckets and entries arrays to the specified size and
@@ -513,7 +496,7 @@ public sealed class QuadDictionary<TKey, TValue> : IQuad<KeyValuePair<TKey, TVal
         }
 
         ArrayPool<int>.Shared.Return(_buckets, clearArray: false);
-        ArrayPool<Entry>.Shared.Return(_entries, clearArray: Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<Entry>());
+        ArrayPool<Entry>.Shared.Return(_entries, clearArray: ArrayPoolClearHelper.IsReferenceOrContainsReferences<Entry>());
 
         _entries = newEntries;
         _buckets = newBuckets;

--- a/src/ReactiveList/Collections/QuadList.cs
+++ b/src/ReactiveList/Collections/QuadList.cs
@@ -120,7 +120,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
             Array.Copy(_items, index + 1, _items, index, _count - index);
         }
 
-        if (!Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>())
+        if (!ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>())
         {
             return;
         }
@@ -159,7 +159,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
     /// <summary>Removes all elements from the list.</summary>
     public void Clear()
     {
-        if (Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>())
+        if (ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>())
         {
             Array.Clear(_items, 0, _count);
         }
@@ -210,7 +210,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
             return;
         }
 
-        ArrayPool<T>.Shared.Return(_items, clearArray: Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
+        ArrayPool<T>.Shared.Return(_items, clearArray: ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
         _items = null!;
     }
 
@@ -262,7 +262,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
             return 0;
         }
 
-        if (Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>())
+        if (ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>())
         {
             Array.Clear(items, writeIndex, removed);
         }
@@ -293,7 +293,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
         var newCapacity = _items.Length == 0 ? MinimumSize : _items.Length * 2;
         if (newCapacity < minCapacity)
         {
-            newCapacity = (int)Internal.BitOperationsCompat.RoundUpToPowerOf2((uint)minCapacity);
+            newCapacity = (int)BitOperationsCompat.RoundUpToPowerOf2((uint)minCapacity);
         }
 
         var newItems = ArrayPool<T>.Shared.Rent(newCapacity);
@@ -302,7 +302,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
             Array.Copy(_items, newItems, _count);
         }
 
-        ArrayPool<T>.Shared.Return(_items, clearArray: Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
+        ArrayPool<T>.Shared.Return(_items, clearArray: ArrayPoolClearHelper.IsReferenceOrContainsReferences<T>());
         _items = newItems;
     }
 
@@ -384,7 +384,7 @@ public sealed class QuadList<T> : IDisposable, IQuad<T>
         public readonly T Current => _list._items[_index];
 
         /// <summary>Gets the current element.</summary>
-        readonly object IEnumerator.Current => Current!;
+        readonly object IEnumerator.Current => Current;
 
         /// <summary>Advances the enumerator to the next element.</summary>
         /// <returns>true if the enumerator was successfully advanced; false if it has passed the end.</returns>

--- a/src/ReactiveList/Collections/QuaternaryBase.cs
+++ b/src/ReactiveList/Collections/QuaternaryBase.cs
@@ -190,8 +190,8 @@ public abstract class QuaternaryBase<TItem, TValue> : IReactiveSource<TItem>, IN
     public abstract IEnumerator<TItem> GetEnumerator();
 
     /// <summary>Returns an enumerator that iterates through a collection.</summary>
-    /// <returns>An <see cref="System.Collections.IEnumerator"/> object that can be used to iterate through the collection.</returns>
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    /// <returns>An <see cref="IEnumerator"/> object that can be used to iterate through the collection.</returns>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <summary>Attempts to enqueue a cache event for processing and increments the version counter.</summary>
     /// <param name="action">The cache action type.</param>
@@ -269,10 +269,7 @@ public abstract class QuaternaryBase<TItem, TValue> : IReactiveSource<TItem>, IN
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected void EmitBatchAddedFromList(IList<TItem> items, int count)
     {
-        if (items is null)
-        {
-            throw new ArgumentNullException(nameof(items));
-        }
+        ThrowHelper.ThrowIfNull(items);
 
         if (!HasChangeObservers())
         {
@@ -331,10 +328,7 @@ public abstract class QuaternaryBase<TItem, TValue> : IReactiveSource<TItem>, IN
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected void EmitBatchRemovedFromList(IList<TItem> items, int count)
     {
-        if (items is null)
-        {
-            throw new ArgumentNullException(nameof(items));
-        }
+        ThrowHelper.ThrowIfNull(items);
 
         if (!HasChangeObservers())
         {
@@ -494,7 +488,7 @@ public abstract class QuaternaryBase<TItem, TValue> : IReactiveSource<TItem>, IN
         if (evt.Batch is not null)
         {
             // Batch operations use Reset to avoid index issues with sharded collections
-            args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
+            args = new(NotifyCollectionChangedAction.Reset);
             evt.Batch.Dispose();
         }
         else
@@ -510,14 +504,7 @@ public abstract class QuaternaryBase<TItem, TValue> : IReactiveSource<TItem>, IN
 
             // For Add/Remove with single items, we can't provide index in sharded collection
             // Use Reset for safety to ensure UI updates correctly
-            if (action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Remove)
-            {
-                args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
-            }
-            else
-            {
-                args = new NotifyCollectionChangedEventArgs(action);
-            }
+            args = action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Remove ? new(NotifyCollectionChangedAction.Reset) : new(action);
         }
 
         // Dispatch to the captured synchronization context (UI thread)

--- a/src/ReactiveList/Collections/QuaternaryDictionary.cs
+++ b/src/ReactiveList/Collections/QuaternaryDictionary.cs
@@ -82,15 +82,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     public TValue this[TKey key]
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
-        {
-            if (TryGetValue(key, out var val))
-            {
-                return val;
-            }
-
-            throw new KeyNotFoundException();
-        }
+        get => TryGetValue(key, out var val) ? val : throw new KeyNotFoundException();
 
         set => AddOrUpdate(key, value);
     }
@@ -313,12 +305,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     public IEnumerable<TValue> GetValuesBySecondaryIndex<TIndexKey>(string indexName, TIndexKey key)
         where TIndexKey : notnull
     {
-        if (Indices.TryGetValue(indexName, out var idx) && idx is SecondaryIndex<TValue, TIndexKey> typedIdx)
-        {
-            return typedIdx.Lookup(key);
-        }
-
-        return [];
+        return Indices.TryGetValue(indexName, out var idx) && idx is SecondaryIndex<TValue, TIndexKey> typedIdx ? typedIdx.Lookup(key) : [];
     }
 
     /// <summary>Creates a reactive view filtered by a secondary index key.</summary>
@@ -335,12 +322,9 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
         int throttleMs = 50)
         where TIndexKey : notnull
     {
-        if (!Indices.TryGetValue(indexName, out var idx) || idx is not SecondaryIndex<TValue, TIndexKey>)
-        {
-            throw new InvalidOperationException($"Secondary index '{indexName}' does not exist or has incompatible type.");
-        }
-
-        return SecondaryIndexReactiveView<TKey, TValue>.Create(
+        return !Indices.TryGetValue(indexName, out var idx) || idx is not SecondaryIndex<TValue, TIndexKey>
+            ? throw new InvalidOperationException($"Secondary index '{indexName}' does not exist or has incompatible type.")
+            : SecondaryIndexReactiveView<TKey, TValue>.Create(
             this,
             indexName,
             key,
@@ -357,12 +341,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     public bool ValueMatchesSecondaryIndex<TIndexKey>(string indexName, TValue value, TIndexKey key)
         where TIndexKey : notnull
     {
-        if (!Indices.TryGetValue(indexName, out var idx))
-        {
-            return false;
-        }
-
-        return idx.MatchesKey(value, key);
+        return Indices.TryGetValue(indexName, out var idx) && idx.MatchesKey(value, key);
     }
 
     /// <summary>Adds the specified key/value pair to the collection.</summary>
@@ -386,19 +365,14 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public (bool HasValue, TValue? Value) Lookup(TKey key)
     {
-        if (TryGetValue(key, out var value))
-        {
-            return (true, value);
-        }
-
-        return (false, default);
+        return TryGetValue(key, out var value) ? (true, value) : (false, default);
     }
 
     /// <summary>Removes all entries with keys in the specified collection from the dictionary.</summary>
     /// <param name="keys">The collection of keys to remove.</param>
     public void RemoveKeys(IEnumerable<TKey> keys)
     {
-        Internal.ThrowHelper.ThrowIfNull(keys);
+        ThrowHelper.ThrowIfNull(keys);
 
         // Fast path for arrays
         if (keys is TKey[] array)
@@ -423,7 +397,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     /// <returns>The number of entries removed from the dictionary.</returns>
     public int RemoveMany(Func<KeyValuePair<TKey, TValue>, bool> predicate)
     {
-        Internal.ThrowHelper.ThrowIfNull(predicate);
+        ThrowHelper.ThrowIfNull(predicate);
 
         var totalRemoved = 0;
 
@@ -451,7 +425,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
                             {
                                 var newBuffer = ArrayPool<TKey>.Shared.Rent(keysBuffer.Length * 2);
                                 keysBuffer.AsSpan(0, keysCount).CopyTo(newBuffer);
-                                ArrayPool<TKey>.Shared.Return(keysBuffer, clearArray: Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
+                                ArrayPool<TKey>.Shared.Return(keysBuffer, clearArray: ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
                                 keysBuffer = newBuffer;
                             }
 
@@ -489,7 +463,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
         }
         finally
         {
-            ArrayPool<TKey>.Shared.Return(keysBuffer, clearArray: Internal.ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
+            ArrayPool<TKey>.Shared.Return(keysBuffer, clearArray: ArrayPoolClearHelper.IsReferenceOrContainsReferences<TKey>());
         }
 
         return totalRemoved;
@@ -499,7 +473,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     /// <param name="editAction">An action that receives the dictionary interface to perform modifications.</param>
     public void Edit(Action<IDictionary<TKey, TValue>> editAction)
     {
-        Internal.ThrowHelper.ThrowIfNull(editAction);
+        ThrowHelper.ThrowIfNull(editAction);
 
         // Acquire all locks for the edit operation
         for (var i = 0; i < ShardCount; i++)
@@ -531,7 +505,7 @@ public class QuaternaryDictionary<TKey, TValue> : QuaternaryBase<KeyValuePair<TK
     /// <exception cref="ArgumentNullException">Thrown when array is null.</exception>
     public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
     {
-        Internal.ThrowHelper.ThrowIfNull(array);
+        ThrowHelper.ThrowIfNull(array);
 
         for (var i = 0; i < ShardCount; i++)
         {

--- a/src/ReactiveList/Collections/QuaternaryList.cs
+++ b/src/ReactiveList/Collections/QuaternaryList.cs
@@ -380,12 +380,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, T>, IQuaternaryList<T>
     public IEnumerable<T> GetItemsBySecondaryIndex<TKey>(string indexName, TKey key)
         where TKey : notnull
     {
-        if (Indices.TryGetValue(indexName, out var idx) && idx is SecondaryIndex<T, TKey> typedIdx)
-        {
-            return typedIdx.Lookup(key);
-        }
-
-        return [];
+        return Indices.TryGetValue(indexName, out var idx) && idx is SecondaryIndex<T, TKey> typedIdx ? typedIdx.Lookup(key) : [];
     }
 
     /// <summary>Determines whether the specified item matches the given key in the specified secondary index.</summary>
@@ -397,12 +392,7 @@ public class QuaternaryList<T> : QuaternaryBase<T, T>, IQuaternaryList<T>
     public bool ItemMatchesSecondaryIndex<TKey>(string indexName, T item, TKey key)
         where TKey : notnull
     {
-        if (!Indices.TryGetValue(indexName, out var idx))
-        {
-            return false;
-        }
-
-        return idx.MatchesKey(item, key);
+        return Indices.TryGetValue(indexName, out var idx) && idx.MatchesKey(item, key);
     }
 
     /// <summary>Determines whether the collection contains a specific value.</summary>

--- a/src/ReactiveList/Collections/Reactive2DList.cs
+++ b/src/ReactiveList/Collections/Reactive2DList.cs
@@ -68,10 +68,7 @@ public class Reactive2DList<T> : ReactiveList<ReactiveList<T>>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="items"/> is null.</exception>
     public void AddRange(IEnumerable<IEnumerable<T>> items)
     {
-        if (items is null)
-        {
-            throw new ArgumentNullException(nameof(items));
-        }
+        ThrowHelper.ThrowIfNull(items);
 
         base.AddRange(items.Select(static item => new ReactiveList<T>(item)).ToArray());
     }
@@ -81,10 +78,7 @@ public class Reactive2DList<T> : ReactiveList<ReactiveList<T>>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="items"/> is null.</exception>
     public void AddRange(IEnumerable<T> items)
     {
-        if (items is null)
-        {
-            throw new ArgumentNullException(nameof(items));
-        }
+        ThrowHelper.ThrowIfNull(items);
 
         base.AddRange(items.Select(static item => new ReactiveList<T>(item)).ToArray());
     }
@@ -98,10 +92,7 @@ public class Reactive2DList<T> : ReactiveList<ReactiveList<T>>
     /// collections.</exception>
     public void AddToInner(int outerIndex, IEnumerable<T> items)
     {
-        if (items is null)
-        {
-            throw new ArgumentNullException(nameof(items));
-        }
+        ThrowHelper.ThrowIfNull(items);
 
         if (outerIndex < 0 || outerIndex >= Count)
         {
@@ -180,10 +171,7 @@ public class Reactive2DList<T> : ReactiveList<ReactiveList<T>>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="items"/> is null.</exception>
     public void Insert(int index, IEnumerable<T> items)
     {
-        if (items is null)
-        {
-            throw new ArgumentNullException(nameof(items));
-        }
+        ThrowHelper.ThrowIfNull(items);
 
         base.Insert(index, [.. items]);
     }
@@ -209,10 +197,7 @@ public class Reactive2DList<T> : ReactiveList<ReactiveList<T>>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="items"/> is null.</exception>
     public void Insert(int index, IEnumerable<T> items, int innerIndex)
     {
-        if (items is null)
-        {
-            throw new ArgumentNullException(nameof(items));
-        }
+        ThrowHelper.ThrowIfNull(items);
 
         this[index].InsertRange(innerIndex, items);
     }

--- a/src/ReactiveList/Collections/ReactiveList.cs
+++ b/src/ReactiveList/Collections/ReactiveList.cs
@@ -414,12 +414,7 @@ public class ReactiveList<T> : IReactiveList<T>
     /// <inheritdoc/>
     public bool Contains(object? value)
     {
-        if (!IsCompatibleObject(value))
-        {
-            return false;
-        }
-
-        return Contains((T)value!);
+        return IsCompatibleObject(value) && Contains((T)value!);
     }
 
     /// <inheritdoc/>
@@ -438,10 +433,7 @@ public class ReactiveList<T> : IReactiveList<T>
     /// <inheritdoc/>
     public void CopyTo(Array array, int index)
     {
-        if (array is null)
-        {
-            throw new ArgumentNullException(nameof(array));
-        }
+        ThrowHelper.ThrowIfNull(array);
 
         if (array.Rank != 1)
         {
@@ -490,10 +482,7 @@ public class ReactiveList<T> : IReactiveList<T>
     /// <param name="editAction">The action to perform on the internal list.</param>
     public void Edit(Action<IEditableList<T>> editAction)
     {
-        if (editAction is null)
-        {
-            throw new ArgumentNullException(nameof(editAction));
-        }
+        ThrowHelper.ThrowIfNull(editAction);
 
         lock (_lock)
         {
@@ -546,12 +535,7 @@ public class ReactiveList<T> : IReactiveList<T>
     /// <inheritdoc/>
     public int IndexOf(object? value)
     {
-        if (IsCompatibleObject(value))
-        {
-            return IndexOf((T)value!);
-        }
-
-        return -1;
+        return IsCompatibleObject(value) ? IndexOf((T)value!) : -1;
     }
 
     /// <inheritdoc/>
@@ -694,10 +678,7 @@ public class ReactiveList<T> : IReactiveList<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int RemoveMany(Func<T, bool> predicate)
     {
-        if (predicate is null)
-        {
-            throw new ArgumentNullException(nameof(predicate));
-        }
+        ThrowHelper.ThrowIfNull(predicate);
 
         lock (_lock)
         {
@@ -927,13 +908,9 @@ public class ReactiveList<T> : IReactiveList<T>
         {
             args = CountPropertyChangedEventArgs;
         }
-        else if (propertyName == ItemArray)
-        {
-            args = ItemArrayPropertyChangedEventArgs;
-        }
         else
         {
-            args = new PropertyChangedEventArgs(propertyName);
+            args = propertyName == ItemArray ? ItemArrayPropertyChangedEventArgs : new(propertyName);
         }
 
         PropertyChanged?.Invoke(this, args);
@@ -1016,12 +993,7 @@ public class ReactiveList<T> : IReactiveList<T>
             return result;
         }
 
-        if (notification.Item is not null)
-        {
-            return [notification.Item];
-        }
-
-        return [];
+        return notification.Item is not null ? [notification.Item] : [];
     }
 
     /// <summary>Sets data for the SetItem operation.</summary>

--- a/src/ReactiveList/Core/CacheNotifyExtensions.cs
+++ b/src/ReactiveList/Core/CacheNotifyExtensions.cs
@@ -24,12 +24,9 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Change<T>? ToChange()
         {
-            if (notification is null)
-            {
-                return null;
-            }
-
-            return notification.Action switch
+            return notification is null
+                ? null
+                : notification.Action switch
             {
                 CacheAction.Added when notification.Item is not null =>
                     Change<T>.CreateAdd(notification.Item, notification.CurrentIndex),
@@ -59,10 +56,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<CacheNotify<T>> WhereAction(CacheAction action)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source.Keep(n => n.Action == action);
         }
@@ -72,10 +66,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<CacheNotify<T>> WhereAdded()
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source.Keep(n => n.Action is CacheAction.Added or CacheAction.BatchAdded);
         }
@@ -85,10 +76,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<CacheNotify<T>> WhereRemoved()
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source.Keep(n => n.Action is CacheAction.Removed or CacheAction.BatchRemoved);
         }
@@ -98,10 +86,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<T> SelectItems()
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source
                 .Keep(n => n.Item is not null)
@@ -113,10 +98,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<T> SelectAllItems()
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source.FlatMap(n =>
             {
@@ -127,12 +109,7 @@ public static class CacheNotifyExtensions
                     return items;
                 }
 
-                if (n.Item is not null)
-                {
-                    return [n.Item];
-                }
-
-                return [];
+                return n.Item is not null ? [n.Item] : [];
             });
         }
 
@@ -156,10 +133,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<(T Item, int OldIndex, int NewIndex)> OnItemMoved()
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source
                 .WhereAction(CacheAction.Moved)
@@ -178,10 +152,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<IList<CacheNotify<T>>> BufferNotifications(TimeSpan bufferTime)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source
                 .Buffer(bufferTime)
@@ -194,10 +165,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<CacheNotify<T>> ThrottleNotifications(TimeSpan throttleTime)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source.Throttle(throttleTime);
         }
@@ -208,15 +176,8 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<CacheNotify<T>> ObserveOnScheduler(ISequencer scheduler)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (scheduler is null)
-            {
-                throw new ArgumentNullException(nameof(scheduler));
-            }
+            ThrowHelper.ThrowIfNull(source);
+            ThrowHelper.ThrowIfNull(scheduler);
 
             return source.ObserveOn(scheduler);
         }
@@ -228,15 +189,8 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<TResult> TransformItems<TResult>(Func<T, TResult> selector)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (selector is null)
-            {
-                throw new ArgumentNullException(nameof(selector));
-            }
+            ThrowHelper.ThrowIfNull(source);
+            ThrowHelper.ThrowIfNull(selector);
 
             return source.SelectAllItems().Map(selector);
         }
@@ -247,15 +201,8 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<T> FilterItems(Func<T, bool> predicate)
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            if (predicate is null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
+            ThrowHelper.ThrowIfNull(source);
+            ThrowHelper.ThrowIfNull(predicate);
 
             return source.SelectAllItems().Keep(predicate);
         }
@@ -265,10 +212,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<CacheNotify<T>> AutoDisposeBatches()
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source.Tap(n => n.Batch?.Dispose());
         }
@@ -278,10 +222,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<(CacheAction Action, int Count)> CountByAction()
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source.Map(n =>
             {
@@ -300,10 +241,7 @@ public static class CacheNotifyExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IObservable<ChangeSet<T>> ToChangeSets()
         {
-            if (source is null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ThrowHelper.ThrowIfNull(source);
 
             return source.Map(notification =>
             {
@@ -346,12 +284,7 @@ public static class CacheNotifyExtensions
                 }
 
                 var change = notification.ToChange();
-                if (change.HasValue)
-                {
-                    return new ChangeSet<T>(change.Value);
-                }
-
-                return ChangeSet<T>.Empty;
+                return change.HasValue ? new ChangeSet<T>(change.Value) : ChangeSet<T>.Empty;
             }).Where(cs => cs.Count > 0);
         }
     }

--- a/src/ReactiveList/Core/ChangeSet.cs
+++ b/src/ReactiveList/Core/ChangeSet.cs
@@ -48,10 +48,7 @@ public readonly record struct ChangeSet<T> : IReadOnlyList<Change<T>>, IDisposab
     /// <param name="changes">The changes array. This array is not copied on .NET Framework.</param>
     public ChangeSet(Change<T>[] changes)
     {
-        if (changes is null)
-        {
-            throw new ArgumentNullException(nameof(changes));
-        }
+        ThrowHelper.ThrowIfNull(changes);
 
 #if NET6_0_OR_GREATER
         _changes = ArrayPool<Change<T>>.Shared.Rent(changes.Length);
@@ -100,15 +97,7 @@ public readonly record struct ChangeSet<T> : IReadOnlyList<Change<T>>, IDisposab
     /// <exception cref="ArgumentOutOfRangeException">index is less than 0 or greater than or equal to Count.</exception>
     public Change<T> this[int index]
     {
-        get
-        {
-            if ((uint)index >= (uint)Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
-
-            return _changes![index];
-        }
+        get => (uint)index >= (uint)Count ? throw new ArgumentOutOfRangeException(nameof(index)) : _changes![index];
     }
 
 #if NET6_0_OR_GREATER

--- a/src/ReactiveList/Core/EditableListWrapperPool.cs
+++ b/src/ReactiveList/Core/EditableListWrapperPool.cs
@@ -43,7 +43,7 @@ public static class EditableListWrapperPool
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static PooledEditableListWrapper<T> Rent<T>(
         List<T> list,
-        System.Collections.ObjectModel.ObservableCollection<T>? observableCollection = null)
+        ObservableCollection<T>? observableCollection = null)
     {
         if (State.Get<T>().TryRent(out var wrapper) && wrapper is not null)
         {

--- a/src/ReactiveList/Core/PooledEditableListWrapper.cs
+++ b/src/ReactiveList/Core/PooledEditableListWrapper.cs
@@ -111,7 +111,7 @@ public sealed class PooledEditableListWrapper<T>(List<T> list, ObservableCollect
     }
 
     /// <inheritdoc/>
-    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     /// <inheritdoc/>
     public int IndexOf(T item)

--- a/src/ReactiveList/Core/ReactiveGroup.cs
+++ b/src/ReactiveList/Core/ReactiveGroup.cs
@@ -22,7 +22,7 @@ public sealed class ReactiveGroup<TKey, T> : IGrouping<TKey, T>, INotifyCollecti
     {
         Key = key;
         _items = items;
-        Items = new ReadOnlyObservableCollection<T>(_items);
+        Items = new(_items);
         _items.CollectionChanged += (s, e) =>
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));

--- a/src/ReactiveList/ReactiveListExtensions.cs
+++ b/src/ReactiveList/ReactiveListExtensions.cs
@@ -241,7 +241,7 @@ public static class ReactiveListExtensions
                 for (var i = 0; i < changes.Count; i++)
                 {
                     var c = changes[i];
-                    transformed[i] = new Change<TResult>(
+                    transformed[i] = new(
                         c.Reason,
                         selector(c.Current),
                         c.Previous is not null ? selector(c.Previous) : default,
@@ -352,7 +352,7 @@ public static class ReactiveListExtensions
                             var group = groups.FirstOrDefault(g => EqualityComparer<TKey>.Default.Equals(g.Key, key));
                             if (group is null)
                             {
-                                group = new GroupedObservable<TKey, T>(key);
+                                group = new(key);
                                 groups.Add(group);
                                 observer.OnNext(group);
                             }

--- a/src/ReactiveList/Views/DynamicFilteredReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicFilteredReactiveView.cs
@@ -48,7 +48,7 @@ where T : notnull
 
         _currentFilter = _ => true;
         _filteredItems = [];
-        Items = new ReadOnlyObservableCollection<T>(_filteredItems);
+        Items = new(_filteredItems);
 
         // Initialize with current items (no filter initially)
         RebuildView();

--- a/src/ReactiveList/Views/DynamicReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicReactiveView.cs
@@ -82,7 +82,7 @@ where T : notnull
         _source = source;
         _throttle = throttle;
         _scheduler = scheduler;
-        Items = new ReadOnlyObservableCollection<T>(_target);
+        Items = new(_target);
 
         var hasInitialFilter = TryGetLatest(filterObservable, out var initialFilter);
         if (hasInitialFilter)

--- a/src/ReactiveList/Views/DynamicSecondaryIndexDictionaryReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicSecondaryIndexDictionaryReactiveView.cs
@@ -61,7 +61,7 @@ where TKey : notnull
         _valueMatchesIndex = valueMatchesIndex ?? throw new ArgumentNullException(nameof(valueMatchesIndex));
 
         _filteredItems = [];
-        Items = new ReadOnlyObservableCollection<KeyValuePair<TKey, TValue>>(_filteredItems);
+        Items = new(_filteredItems);
 
         var hasInitialKeys = TryGetLatest(keysObservable, out var initialKeys);
         _currentKeys = initialKeys?.ToHashSet() ?? [];
@@ -133,7 +133,7 @@ where TKey : notnull
             typedKeys,
             scheduler,
             throttle,
-            static (dict, name, key) => dict.GetValuesBySecondaryIndex<TIndexKey>(name, (TIndexKey)key),
+            static (dict, name, key) => dict.GetValuesBySecondaryIndex(name, (TIndexKey)key),
             static (dict, name, value, key) => dict.ValueMatchesSecondaryIndex(name, value, (TIndexKey)key));
     }
 

--- a/src/ReactiveList/Views/DynamicSecondaryIndexReactiveView.cs
+++ b/src/ReactiveList/Views/DynamicSecondaryIndexReactiveView.cs
@@ -47,7 +47,7 @@ where TKey : notnull
         ThrowHelper.ThrowIfNull(keysObservable);
 
         _filteredItems = [];
-        Items = new ReadOnlyObservableCollection<T>(_filteredItems);
+        Items = new(_filteredItems);
 
         var hasInitialKeys = TryGetLatest(keysObservable, out var initialKeys);
         _currentKeys = initialKeys?.ToHashSet() ?? [];

--- a/src/ReactiveList/Views/FilteredReactiveView.cs
+++ b/src/ReactiveList/Views/FilteredReactiveView.cs
@@ -37,7 +37,7 @@ where T : notnull
         _filter = filter ?? throw new ArgumentNullException(nameof(filter));
 
         _filteredItems = [];
-        Items = new ReadOnlyObservableCollection<T>(_filteredItems);
+        Items = new(_filteredItems);
 
         // Initialize with current items
         RebuildView();

--- a/src/ReactiveList/Views/GroupedReactiveView.cs
+++ b/src/ReactiveList/Views/GroupedReactiveView.cs
@@ -40,7 +40,7 @@ where TKey : notnull
         _source = source ?? throw new ArgumentNullException(nameof(source));
         _keySelector = keySelector ?? throw new ArgumentNullException(nameof(keySelector));
 
-        Groups = new ReadOnlyObservableCollection<ReactiveGroup<TKey, T>>(_groupCollection);
+        Groups = new(_groupCollection);
 
         // Initialize with current items
         RebuildView();

--- a/src/ReactiveList/Views/ReactiveView.cs
+++ b/src/ReactiveList/Views/ReactiveView.cs
@@ -49,7 +49,7 @@ where T : notnull
     public ReactiveView(IObservable<CacheNotify<T>> stream, IEnumerable<T> snapshot, Func<T, bool> filter, TimeSpan throttle, ISequencer sheduler)
 #endif
     {
-        Items = new ReadOnlyObservableCollection<T>(_target);
+        Items = new(_target);
 
         if (stream is null)
         {

--- a/src/ReactiveList/Views/SecondaryIndexReactiveView.cs
+++ b/src/ReactiveList/Views/SecondaryIndexReactiveView.cs
@@ -56,7 +56,7 @@ where TKey : notnull
         _valueMatchesIndex = valueMatchesIndex ?? throw new ArgumentNullException(nameof(valueMatchesIndex));
 
         _filteredItems = [];
-        Items = new ReadOnlyObservableCollection<TValue>(_filteredItems);
+        Items = new(_filteredItems);
 
         // Initialize with current matching items
         RebuildView();

--- a/src/ReactiveList/Views/SortedReactiveView.cs
+++ b/src/ReactiveList/Views/SortedReactiveView.cs
@@ -37,7 +37,7 @@ where T : notnull
         _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
 
         _sortedItems = [];
-        Items = new ReadOnlyObservableCollection<T>(_sortedItems);
+        Items = new(_sortedItems);
 
         // Initialize with current items sorted
         RebuildView();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor / analyzer cleanup for the ReactiveList library implementation.

## What is the new behavior?

There is no intended public API or runtime behavior change. The implementation now uses simpler analyzer-preferred constructs, including collapsed conditionals, target-typed object creation, and existing `ThrowHelper.ThrowIfNull` calls in collection paths.

## What is the current behavior?

The same behavior was implemented with more verbose branching, explicit object creation types, and direct `ArgumentNullException` construction in several places.

## Checklist
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the main branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Validation performed locally:

- `git diff --check`
- `./build.cmd Compile --configuration Release`

The compile target passes. Existing analyzer warnings are still emitted as warnings by the current project configuration.